### PR TITLE
fix: don't use file extension when registering runtime plugins

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -206,21 +206,21 @@ export default defineNuxtModule<ModuleOptions>({
     const runtimeDir = resolver.resolve('./runtime')
 
     addPlugin({
-      src: resolver.resolve(runtimeDir, 'plugins/vuetify.ts'),
+      src: resolver.resolve(runtimeDir, `plugins/vuetify${i18n ? '-sync' : ''}`),
     })
     addPlugin({
-      src: resolver.resolve(runtimeDir, 'plugins/vuetify-icons.ts'),
+      src: resolver.resolve(runtimeDir, 'plugins/vuetify-icons'),
     })
 
     if (i18n) {
       addPlugin({
-        src: resolver.resolve(runtimeDir, 'plugins/vuetify-i18n.ts'),
+        src: resolver.resolve(runtimeDir, 'plugins/vuetify-i18n'),
       })
     }
 
     if (dateAdapter) {
       addPlugin({
-        src: resolver.resolve(runtimeDir, 'plugins/vuetify-date.ts'),
+        src: resolver.resolve(runtimeDir, 'plugins/vuetify-date'),
       })
     }
   },

--- a/src/runtime/plugins/vuetify-sync.ts
+++ b/src/runtime/plugins/vuetify-sync.ts
@@ -5,6 +5,8 @@ import { useNuxtApp } from '#app'
 export default defineNuxtPlugin({
   name: 'vuetify:configuration:plugin',
   enforce: 'post',
+  // i18n runtime plugin is async
+  parallel: false,
   setup() {
     useNuxtApp().hook('app:created', configureVuetify)
   },


### PR DESCRIPTION
This PR also splits vuetify runtime plugin into async and sync ones: `parallel: false` only required when i18n installed (we need to await i18n async plugin to be ready)