### PR TITLE
feat: allow load Vuetify translation messages

### DIFF
--- a/docs/guide/date.md
+++ b/docs/guide/date.md
@@ -1,9 +1,5 @@
 # Date Support
 
-:::warning
-Right now you can only use Vuetify adapter, there is a bug and will not work, I'm working on it: https://github.com/userquin/vuetify-nuxt-module/pull/9#issuecomment-1620023814.
-:::
-
 Use Vuetify components [that require date functionality](https://vuetifyjs.com/en/features/dates/) installing and configuring one of the [@date-io](https://github.com/dmtrKovalenko/date-io#projects) adapters.
 
 To use Vuetify components [that require date functionality](https://vuetifyjs.com/en/features/dates/):

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -166,10 +166,19 @@ export interface VOptions extends Partial<Omit<VuetifyOptions, 'ssr' | 'aliases'
    * - `locale`
    * - `fallback`
    * - `rtl`
-   *
+   * - `messages`
+   * 
    * The adapter will be `vuetify`, if you want to use another adapter, check `date` option.
    */
   locale?: Omit<LocaleOptions, 'adapter'> & RtlOptions
+  /**
+   * Include locale messages?
+   *
+   * When `@nuxtjs/i18n` Nuxt module is present, this option will be ignored.
+   *
+   * You can include the locales you want to use in your application, this module will load and configure the messages for you.
+   */
+  localeMessages?: VuetifyLocale | VuetifyLocale[]
   /**
    * Include the lab components?
    *
@@ -230,6 +239,88 @@ import { defineNuxtPlugin } from '#imports'
 export default defineNuxtPlugin((nuxtApp) => {
   nuxtApp.hook('vuetify:before-create', ({ vuetifyOptions }) => {
     // update vuetifyOptions
+  })
+})
+```
+
+## Load Vuetify Messages
+
+You can load Vuetify messages using the `vuetifyOptions.loadMessages` module configuration option, you don't need to configure a Nuxt Plugin with the `vuetify:before-create` hook.
+
+:::warning
+When `@nuxtjs/i18n` Nuxt module is present, `vuetifyOptions.loadMessages` module configuration option will be ignored.
+:::
+
+Using the example in [Vuetify I18n](https://vuetifyjs.com/en/features/internationalization/#getting-started) documentation:
+```ts
+// Nuxt config file
+import { defineNuxtConfig } from 'nuxt/config'
+
+export default defineNuxtConfig({
+  modules: [
+    'vuetify-nuxt-module'
+  ],
+  vuetify: {
+    moduleOptions: {
+      /* module specific options */
+    },
+    vuetifyOptions: {
+      locale: {
+        locale: 'zhHans',
+        fallback: 'sv',  
+      },
+      loadMessages: ['zhHans', 'pl'],
+      /* other vuetify options */
+    }
+  }
+})
+```
+
+Previous configuration will load and configure `zhHans` and `pl` Vuetify messages.
+
+If you have more messages than the default ones provided by Vuetify, you can add them to the locale messages entry or add them adding a new Nuxt plugin registering them in the `vuetify:before-create` hook (remember to merge the messages).
+
+Following with the Vuetify example:
+```ts
+// Nuxt config file
+import { defineNuxtConfig } from 'nuxt/config'
+
+export default defineNuxtConfig({
+  modules: [
+    'vuetify-nuxt-module'
+  ],
+  vuetify: {
+    moduleOptions: {
+      /* module specific options */
+    },
+    vuetifyOptions: {
+      locale: {
+        locale: 'zhHans',
+        fallback: 'sv',
+        messages: {
+          sv: {
+            /* your custom messages here */
+          }
+        }
+      },
+      loadMessages: ['zhHans', 'pl'],
+      /* other vuetify options */
+    }
+  }
+})
+```
+
+This module will merge the messages for you, so you don't need to worry about it.
+
+If you want to load your custom messages from a Nuxt Plugin:
+```ts
+import { defineNuxtPlugin } from '#imports'
+// Your own translation file
+import sv from './i18n/vuetify/sv'
+
+export default defineNuxtPlugin((nuxtApp) => {
+  nuxtApp.hook('vuetify:before-create', ({ vuetifyOptions }) => {
+    vuetifyOptions.locale.messages.sv = sv
   })
 })
 ```

--- a/package.json
+++ b/package.json
@@ -59,13 +59,13 @@
   "peerDependencies": {
     "@nuxt/kit": "^3.6.2",
     "vite-plugin-vuetify": "^1.0.2",
-    "vuetify": "^3.3.6"
+    "vuetify": "^3.3.9"
   },
   "dependencies": {
     "@nuxt/kit": "^3.6.2",
     "defu": "^6.1.2",
     "vite-plugin-vuetify": "^1.0.2",
-    "vuetify": "^3.3.6"
+    "vuetify": "^3.3.9"
   },
   "devDependencies": {
     "@antfu/eslint-config": "^0.39.6",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vuetify-nuxt-module",
   "type": "module",
   "version": "0.4.7",
-  "packageManager": "pnpm@8.6.8",
+  "packageManager": "pnpm@8.6.9",
   "description": "Zero-Config Nuxt Module for Vuetify",
   "author": "userquin <userquin@gmail.com>",
   "license": "MIT",

--- a/playground/locales/multiple/ar.json
+++ b/playground/locales/multiple/ar.json
@@ -9,6 +9,9 @@
       "input": {
         "placeholder": "أدخل اليوم"
       }
+    },
+    "input": {
+      "clear": "يمسح"
     }
   }
 }

--- a/playground/locales/single/ar-EG.json
+++ b/playground/locales/single/ar-EG.json
@@ -9,6 +9,9 @@
       "input": {
         "placeholder": "أدخل اليوم"
       }
+    },
+    "input": {
+      "clear": "Limpiar"
     }
   }
 }

--- a/playground/nuxt.config.mts
+++ b/playground/nuxt.config.mts
@@ -46,12 +46,20 @@ export default defineNuxtConfig({
       components: ['VDialog', 'VExpansionPanel', 'VExpansionPanelText', 'VExpansionPanelTitle'],
       labComponents: ['VDataTable', 'VDatePickerControls', 'VDatePickerHeader'],
       blueprint: md3,
+      /*locale: {
+        messages: {
+          en: {
+            one: 'One',
+          },
+        },
+      },
+      localeMessages: ['en', 'es', 'ar'],*/
       theme: {
         defaultTheme: 'light',
       },
       date: {
-        // adapter: 'luxon',
-        adapter: 'vuetify',
+        adapter: 'luxon',
+        // adapter: 'vuetify',
       },
       icons: {
         // remember to comment the v-icon in playground/pages/index.vue when switching

--- a/playground/pages/index.vue
+++ b/playground/pages/index.vue
@@ -16,22 +16,18 @@ const { isRtl } = useRtl()
 // eslint-disable-next-line no-console
 console.log(useNuxtApp().$vuetify.icons)
 
-const rtl = ref(isRtl.value)
+// const rtl = ref(isRtl.value)
 
 watch(isRtl, (x) => {
   // eslint-disable-next-line no-console
   console.log('isRtl', x)
-  rtl.value = x
+  // rtl.value = x
 }, { immediate: true })
 
 watch(current, () => {
   // eslint-disable-next-line no-console
   console.log('current', t('xxx', { locale: current.value }))
 })
-watch(isRtl, (x) => {
-  // eslint-disable-next-line no-console
-  console.log('isRtl', x)
-}, { immediate: true })
 </script>
 
 <template>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,10 +21,10 @@ importers:
         version: 6.1.2
       vite-plugin-vuetify:
         specifier: ^1.0.2
-        version: 1.0.2(vite@4.3.9)(vue@3.3.4)(vuetify@3.3.6)
+        version: 1.0.2(vite@4.3.9)(vue@3.3.4)(vuetify@3.3.9)
       vuetify:
-        specifier: ^3.3.6
-        version: 3.3.6(typescript@5.1.6)(vite-plugin-vuetify@1.0.2)(vue@3.3.4)
+        specifier: ^3.3.9
+        version: 3.3.9(typescript@5.1.6)(vite-plugin-vuetify@1.0.2)(vue@3.3.4)
     devDependencies:
       '@antfu/eslint-config':
         specifier: ^0.39.6
@@ -128,7 +128,7 @@ importers:
         version: 0.53.5(postcss@8.4.24)(rollup@2.79.1)(vite@4.3.9)
       vitepress:
         specifier: 1.0.0-beta.5
-        version: 1.0.0-beta.5(@algolia/client-search@4.18.0)(@types/node@20.4.1)(sass@1.63.6)(search-insights@2.7.0)
+        version: 1.0.0-beta.5(@types/node@20.4.1)(sass@1.63.6)(search-insights@2.7.0)
 
 packages:
 
@@ -137,47 +137,51 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
-  /@algolia/autocomplete-core@1.9.3(@algolia/client-search@4.18.0)(algoliasearch@4.18.0)(search-insights@2.7.0):
+  /@algolia/autocomplete-core@1.9.3(algoliasearch@4.18.0)(search-insights@2.7.0):
     resolution: {integrity: sha512-009HdfugtGCdC4JdXUbVJClA0q0zh24yyePn+KUGk3rP7j8FEe/m5Yo/z65gn6nP/cM39PxpzqKrL7A6fP6PPw==}
     dependencies:
-      '@algolia/autocomplete-plugin-algolia-insights': 1.9.3(@algolia/client-search@4.18.0)(algoliasearch@4.18.0)(search-insights@2.7.0)
-      '@algolia/autocomplete-shared': 1.9.3(@algolia/client-search@4.18.0)(algoliasearch@4.18.0)
+      '@algolia/autocomplete-plugin-algolia-insights': 1.9.3(algoliasearch@4.18.0)(search-insights@2.7.0)
+      '@algolia/autocomplete-shared': 1.9.3(algoliasearch@4.18.0)
     transitivePeerDependencies:
       - '@algolia/client-search'
       - algoliasearch
       - search-insights
     dev: true
 
-  /@algolia/autocomplete-plugin-algolia-insights@1.9.3(@algolia/client-search@4.18.0)(algoliasearch@4.18.0)(search-insights@2.7.0):
+  /@algolia/autocomplete-plugin-algolia-insights@1.9.3(algoliasearch@4.18.0)(search-insights@2.7.0):
     resolution: {integrity: sha512-a/yTUkcO/Vyy+JffmAnTWbr4/90cLzw+CC3bRbhnULr/EM0fGNvM13oQQ14f2moLMcVDyAx/leczLlAOovhSZg==}
     peerDependencies:
       search-insights: '>= 1 < 3'
     dependencies:
-      '@algolia/autocomplete-shared': 1.9.3(@algolia/client-search@4.18.0)(algoliasearch@4.18.0)
+      '@algolia/autocomplete-shared': 1.9.3(algoliasearch@4.18.0)
       search-insights: 2.7.0
     transitivePeerDependencies:
       - '@algolia/client-search'
       - algoliasearch
     dev: true
 
-  /@algolia/autocomplete-preset-algolia@1.9.3(@algolia/client-search@4.18.0)(algoliasearch@4.18.0):
+  /@algolia/autocomplete-preset-algolia@1.9.3(algoliasearch@4.18.0):
     resolution: {integrity: sha512-d4qlt6YmrLMYy95n5TB52wtNDr6EgAIPH81dvvvW8UmuWRgxEtY0NJiPwl/h95JtG2vmRM804M0DSwMCNZlzRA==}
     peerDependencies:
       '@algolia/client-search': '>= 4.9.1 < 6'
       algoliasearch: '>= 4.9.1 < 6'
+    peerDependenciesMeta:
+      '@algolia/client-search':
+        optional: true
     dependencies:
-      '@algolia/autocomplete-shared': 1.9.3(@algolia/client-search@4.18.0)(algoliasearch@4.18.0)
-      '@algolia/client-search': 4.18.0
+      '@algolia/autocomplete-shared': 1.9.3(algoliasearch@4.18.0)
       algoliasearch: 4.18.0
     dev: true
 
-  /@algolia/autocomplete-shared@1.9.3(@algolia/client-search@4.18.0)(algoliasearch@4.18.0):
+  /@algolia/autocomplete-shared@1.9.3(algoliasearch@4.18.0):
     resolution: {integrity: sha512-Wnm9E4Ye6Rl6sTTqjoymD+l8DjSTHsHboVRYrKgEt8Q7UHm9nYbqhN/i0fhUYA3OAEH7WA8x3jfpnmJm3rKvaQ==}
     peerDependencies:
       '@algolia/client-search': '>= 4.9.1 < 6'
       algoliasearch: '>= 4.9.1 < 6'
+    peerDependenciesMeta:
+      '@algolia/client-search':
+        optional: true
     dependencies:
-      '@algolia/client-search': 4.18.0
       algoliasearch: 4.18.0
     dev: true
 
@@ -1681,10 +1685,10 @@ packages:
     resolution: {integrity: sha512-2Pu9HDg/uP/IT10rbQ+4OrTQuxIWdKVUEdcw9/w7kZJv9NeHS6skJx1xuRiFyoGKwAzcHXnLp7csE99sj+O1YA==}
     dev: true
 
-  /@docsearch/js@3.5.1(@algolia/client-search@4.18.0)(search-insights@2.7.0):
+  /@docsearch/js@3.5.1(search-insights@2.7.0):
     resolution: {integrity: sha512-EXi8de5njxgP6TV3N9ytnGRLG9zmBNTEZjR4VzwPcpPLbZxxTLG2gaFyJyKiFVQxHW/DPlMrDJA3qoRRGEkgZw==}
     dependencies:
-      '@docsearch/react': 3.5.1(@algolia/client-search@4.18.0)(search-insights@2.7.0)
+      '@docsearch/react': 3.5.1(search-insights@2.7.0)
       preact: 10.16.0
     transitivePeerDependencies:
       - '@algolia/client-search'
@@ -1694,7 +1698,7 @@ packages:
       - search-insights
     dev: true
 
-  /@docsearch/react@3.5.1(@algolia/client-search@4.18.0)(search-insights@2.7.0):
+  /@docsearch/react@3.5.1(search-insights@2.7.0):
     resolution: {integrity: sha512-t5mEODdLzZq4PTFAm/dvqcvZFdPDMdfPE5rJS5SC8OUq9mPzxEy6b+9THIqNM9P0ocCb4UC5jqBrxKclnuIbzQ==}
     peerDependencies:
       '@types/react': '>= 16.8.0 < 19.0.0'
@@ -1708,8 +1712,8 @@ packages:
       react-dom:
         optional: true
     dependencies:
-      '@algolia/autocomplete-core': 1.9.3(@algolia/client-search@4.18.0)(algoliasearch@4.18.0)(search-insights@2.7.0)
-      '@algolia/autocomplete-preset-algolia': 1.9.3(@algolia/client-search@4.18.0)(algoliasearch@4.18.0)
+      '@algolia/autocomplete-core': 1.9.3(algoliasearch@4.18.0)(search-insights@2.7.0)
+      '@algolia/autocomplete-preset-algolia': 1.9.3(algoliasearch@4.18.0)
       '@docsearch/css': 3.5.1
       algoliasearch: 4.18.0
     transitivePeerDependencies:
@@ -3987,7 +3991,7 @@ packages:
   /@vue/shared@3.3.4:
     resolution: {integrity: sha512-7OjdcV8vQ74eiz1TZLzZP4JwqM5fA94K6yntPS5Z25r9HDuGNzaGdgvwKYq6S+MxwF0TFRwe50fIR/MYnakdkQ==}
 
-  /@vuetify/loader-shared@1.7.1(vue@3.3.4)(vuetify@3.3.6):
+  /@vuetify/loader-shared@1.7.1(vue@3.3.4)(vuetify@3.3.9):
     resolution: {integrity: sha512-kLUvuAed6RCvkeeTNJzuy14pqnkur8lTuner7v7pNE/kVhPR97TuyXwBSBMR1cJeiLiOfu6SF5XlCYbXByEx1g==}
     peerDependencies:
       vue: ^3.0.0
@@ -3996,7 +4000,7 @@ packages:
       find-cache-dir: 3.3.2
       upath: 2.0.1
       vue: 3.3.4
-      vuetify: 3.3.6(typescript@5.1.6)(vite-plugin-vuetify@1.0.2)(vue@3.3.4)
+      vuetify: 3.3.9(typescript@5.1.6)(vite-plugin-vuetify@1.0.2)(vue@3.3.4)
     dev: false
 
   /@vueuse/core@10.2.1(vue@3.3.4):
@@ -11094,18 +11098,18 @@ packages:
       - supports-color
     dev: true
 
-  /vite-plugin-vuetify@1.0.2(vite@4.3.9)(vue@3.3.4)(vuetify@3.3.6):
+  /vite-plugin-vuetify@1.0.2(vite@4.3.9)(vue@3.3.4)(vuetify@3.3.9):
     resolution: {integrity: sha512-MubIcKD33O8wtgQXlbEXE7ccTEpHZ8nPpe77y9Wy3my2MWw/PgehP9VqTp92BLqr0R1dSL970Lynvisx3UxBFw==}
     engines: {node: '>=12'}
     peerDependencies:
       vite: ^2.7.0 || ^3.0.0 || ^4.0.0
       vuetify: ^3.0.0-beta.4
     dependencies:
-      '@vuetify/loader-shared': 1.7.1(vue@3.3.4)(vuetify@3.3.6)
+      '@vuetify/loader-shared': 1.7.1(vue@3.3.4)(vuetify@3.3.9)
       debug: 4.3.4
       upath: 2.0.1
       vite: 4.3.9(@types/node@18.0.0)(sass@1.63.6)
-      vuetify: 3.3.6(typescript@5.1.6)(vite-plugin-vuetify@1.0.2)(vue@3.3.4)
+      vuetify: 3.3.9(typescript@5.1.6)(vite-plugin-vuetify@1.0.2)(vue@3.3.4)
     transitivePeerDependencies:
       - supports-color
       - vue
@@ -11215,12 +11219,12 @@ packages:
       fsevents: 2.3.2
     dev: true
 
-  /vitepress@1.0.0-beta.5(@algolia/client-search@4.18.0)(@types/node@20.4.1)(sass@1.63.6)(search-insights@2.7.0):
+  /vitepress@1.0.0-beta.5(@types/node@20.4.1)(sass@1.63.6)(search-insights@2.7.0):
     resolution: {integrity: sha512-/RjqqRsSEKkzF6HhK5e5Ij+bZ7ETb9jNCRRgIMm10gJ+ZLC3D1OqkE465lEqCeJUgt2HZ6jmWjDqIBfrJSpv7w==}
     hasBin: true
     dependencies:
       '@docsearch/css': 3.5.1
-      '@docsearch/js': 3.5.1(@algolia/client-search@4.18.0)(search-insights@2.7.0)
+      '@docsearch/js': 3.5.1(search-insights@2.7.0)
       '@vitejs/plugin-vue': 4.2.3(vite@4.4.0-beta.3)(vue@3.3.4)
       '@vue/devtools-api': 6.5.0
       '@vueuse/core': 10.2.1(vue@3.3.4)
@@ -11491,8 +11495,8 @@ packages:
       '@vue/server-renderer': 3.3.4(vue@3.3.4)
       '@vue/shared': 3.3.4
 
-  /vuetify@3.3.6(typescript@5.1.6)(vite-plugin-vuetify@1.0.2)(vue@3.3.4):
-    resolution: {integrity: sha512-9QHh3mY5dK2Y4FGGBHFaIl/RVoP3Wg+XzP/pvruAoglIsUqzMlHrUOYAjO6/SWTxmhsiPI1jl4TyEBlppMXtNQ==}
+  /vuetify@3.3.9(typescript@5.1.6)(vite-plugin-vuetify@1.0.2)(vue@3.3.4):
+    resolution: {integrity: sha512-Oh7iLYvhd99MyVqH8nrK5rai7t2R9ivuiZAZKE0sfP4x0MSYthXRPBqXi4Vy98R7MggNFaoMBDJ/hPscuRxnQA==}
     engines: {node: ^12.20 || >=14.13}
     peerDependencies:
       typescript: '>=4.7'
@@ -11511,7 +11515,7 @@ packages:
         optional: true
     dependencies:
       typescript: 5.1.6
-      vite-plugin-vuetify: 1.0.2(vite@4.3.9)(vue@3.3.4)(vuetify@3.3.6)
+      vite-plugin-vuetify: 1.0.2(vite@4.3.9)(vue@3.3.4)(vuetify@3.3.9)
       vue: 3.3.4
     dev: false
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -92,8 +92,9 @@ export type DirectiveName = keyof typeof import('vuetify/directives')
 export type Directives = boolean | DirectiveName | DirectiveName[]
 export type LabComponentName = keyof typeof import('vuetify/labs/components')
 export type LabComponents = boolean | LabComponentName | LabComponentName[]
+export type VuetifyLocale = keyof typeof import('vuetify/locale')
 
-export interface VOptions extends Partial<Omit<VuetifyOptions, 'ssr' | 'aliases' | 'components' | 'directives' | 'locale' | 'date' | 'icons'>> {
+export interface VOptions extends Partial<Omit<VuetifyOptions, | 'ssr' | 'aliases' | 'components' | 'directives' | 'locale' | 'date' | 'icons'>> {
   aliases?: Record<string, ComponentName>
   /**
    * Do you need to configure some global components?.
@@ -108,10 +109,19 @@ export interface VOptions extends Partial<Omit<VuetifyOptions, 'ssr' | 'aliases'
    * - `locale`
    * - `fallback`
    * - `rtl`
+   * - `messages`
    *
    * The adapter will be `vuetify`, if you want to use another adapter, check `date` option.
    */
   locale?: Omit<LocaleOptions, 'adapter'> & RtlOptions
+  /**
+   * Include locale messages?
+   *
+   * When `@nuxtjs/i18n` Nuxt module is present, this option will be ignored.
+   *
+   * You can include the locales you want to use in your application, this module will load and configure the messages for you.
+   */
+  localeMessages?: VuetifyLocale | VuetifyLocale[]
   /**
    * Include the lab components?
    *


### PR DESCRIPTION
This PR includes:
- allow load Vuetify translation messages just configuring the locales to load and configure via `vuetifyOptions.localeMessages` module option
- bump pnpm to 8.6.9
- bump vuetify to 3.3.9: v-date-picker working and date adapter also working (only tested luxon)
- allow configure date adapters
- docs: included new `vuetifyOptions.localeMessages` module option, updated types and removed warning about