### PR TITLE
fix: load configuration when missing vuetify module option

### DIFF
--- a/playground/layers/vuetify-layer/nuxt.config.ts
+++ b/playground/layers/vuetify-layer/nuxt.config.ts
@@ -1,12 +1,12 @@
 export default defineNuxtConfig({
   // since it is local, the path is relative to the playground folder
   modules: ['../src/module'],
-  vuetify: {
-    vuetifyOptions: './vuetify.config.ts',
-    /* vuetifyOptions: {
+  // vuetify: {
+  // vuetifyOptions: './vuetify.config.ts',
+  /* vuetifyOptions: {
       aliases: {
         MyAvatar: 'VAvatar',
       },
     }, */
-  },
+  // },
 })

--- a/playground/nuxt.config.mts
+++ b/playground/nuxt.config.mts
@@ -33,12 +33,12 @@ export default defineNuxtConfig({
     // debug: true,
     vueI18n: './config/i18n.config.ts',
   },
-  vuetify: {
-    /* moduleOptions: {
+  // vuetify: {
+  /* moduleOptions: {
       styles: { configFile: '/settings.scss' },
     }, */
-    // vuetifyOptions: './vuetify.config.mts',
-    /* vuetifyOptions: {
+  // vuetifyOptions: './vuetify.config.mts',
+  /* vuetifyOptions: {
       ssr: {
         clientWidth: 100,
       },
@@ -90,7 +90,7 @@ export default defineNuxtConfig({
         },*!/
       },
     }, */
-  },
+  // },
   vite: {
     clearScreen: false,
     define: {

--- a/src/utils/layers.ts
+++ b/src/utils/layers.ts
@@ -18,20 +18,18 @@ export async function mergeVuetifyModules(options: ModuleOptions, nuxt: Nuxt) {
   if (nuxt.options._layers.length > 1) {
     for (let i = 1; i < nuxt.options._layers.length; i++) {
       const layer = nuxt.options._layers[i]
-      if (layer.config.vuetify) {
-        const resolvedOptions = await loadVuetifyConfiguration(
-          layer.config.rootDir,
-          layer.config.vuetify.vuetifyOptions,
-        )
+      const resolvedOptions = await loadVuetifyConfiguration(
+        layer.config.rootDir,
+        layer.config.vuetify?.vuetifyOptions,
+      )
 
-        if (resolvedOptions.sources.length)
-          resolvedOptions.sources.forEach(s => vuetifyConfigurationFilesToWatch.add(s.replace(/\\/g, '/')))
+      if (resolvedOptions.sources.length)
+        resolvedOptions.sources.forEach(s => vuetifyConfigurationFilesToWatch.add(s.replace(/\\/g, '/')))
 
-        moduleOptions.push({
-          moduleOptions: layer.config.vuetify.moduleOptions,
-          vuetifyOptions: resolvedOptions.config,
-        })
-      }
+      moduleOptions.push({
+        moduleOptions: layer.config.vuetify?.moduleOptions,
+        vuetifyOptions: resolvedOptions.config,
+      })
     }
   }
 

--- a/src/vite/vuetify-configuration-plugin.ts
+++ b/src/vite/vuetify-configuration-plugin.ts
@@ -27,6 +27,7 @@ export function vuetifyConfigurationPlugin(ctx: VuetifyNuxtContext) {
           icons: _icons,
           localeMessages: _localeMessages,
           components: _components,
+          labComponents: _labComponents,
           ssr,
           aliases: _aliases,
           ...newVuetifyOptions


### PR DESCRIPTION
When vuetify is missing in the Nuxt configuration file it fails or the module doesn't load the default configuration file when using layers.

This PR aso removes `labComponents` from the Vuetify virtual configuration module.