### PR TITLE
docs: include aliases hint in blueprints

### DIFF
--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -455,4 +455,5 @@ The module supports Vuetify Blueprints, just add it to the `vuetifyOptions.bluep
 - `locale` will be ignored, configure it using the `vuetifyOptions.locale` module option
 - `date` will be ignored, configure it using the `vuetifyOptions.date` module option
 - `icons` will be ignored, configure it using the `vuetifyOptions.icons` module option
+- `aliases` only supports defining aliases with [strings](/guide/globals/global-components.html#aliasing-global-component), using component type will result in error (`Cannot start nuxt:  Unexpected token '.'`)
 


### PR DESCRIPTION
Mention about blueprint aliases only supporting strings. Mentioned the error so if someone is googling it they could find this page.