### PR TITLE
fix!: runtime SSR Client Hints types

### DIFF
--- a/playground/settings.scss
+++ b/playground/settings.scss
@@ -1,4 +1,5 @@
-@use 'vuetify/settings' with (
+/* DON'T USE @use here */
+@forward 'vuetify/settings' with (
   $utilities: false,
   $button-height: 40px,
 );

--- a/src/runtime/plugins/client-hints.ts
+++ b/src/runtime/plugins/client-hints.ts
@@ -5,17 +5,13 @@ export interface ClientHintRequestFeatures {
   viewportHeightAvailable: boolean
   viewportWidthAvailable: boolean
 }
-export interface ClientHintsRequest extends ClientHintRequestFeatures {
+export interface SSRClientHints extends ClientHintRequestFeatures {
   prefersColorScheme?: 'dark' | 'light' | 'no-preference'
   prefersReducedMotion?: 'no-preference' | 'reduce'
   viewportHeight?: number
   viewportWidth?: number
   colorSchemeFromCookie?: string
   colorSchemeCookie?: string
-}
-
-export interface SSRClientHints {
-  ssrClientHints: ClientHintsRequest
 }
 
 export const VuetifyHTTPClientHints = 'vuetify:nuxt:ssr-client-hints'

--- a/src/runtime/plugins/vuetify-client-hints.client.ts
+++ b/src/runtime/plugins/vuetify-client-hints.client.ts
@@ -13,7 +13,7 @@ export default defineNuxtPlugin((nuxtApp) => {
     prefersReducedMotionAvailable,
     viewportHeightAvailable,
     viewportWidthAvailable,
-  } = state.value.ssrClientHints
+  } = state.value
 
   const {
     reloadOnFirstRequest,
@@ -26,13 +26,13 @@ export default defineNuxtPlugin((nuxtApp) => {
   // reload the page when it is the first request, explicitly configured, and any feature available
   if (firstRequest && reloadOnFirstRequest) {
     if (prefersColorScheme) {
-      const themeCookie = state.value.ssrClientHints.colorSchemeCookie
+      const themeCookie = state.value.colorSchemeCookie
       // write the cookie and refresh the page if configured
       if (prefersColorSchemeOptions && themeCookie) {
         const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches
         const cookieName = prefersColorSchemeOptions.cookieName
         const parseCookieName = `${cookieName}=`
-        const cookieEntry = `${parseCookieName}${state.value.ssrClientHints.colorSchemeFromCookie ?? prefersColorSchemeOptions.defaultTheme};`
+        const cookieEntry = `${parseCookieName}${state.value.colorSchemeFromCookie ?? prefersColorSchemeOptions.defaultTheme};`
         const newThemeName = prefersDark ? prefersColorSchemeOptions.darkThemeName : prefersColorSchemeOptions.lightThemeName
         document.cookie = themeCookie.replace(cookieEntry, `${cookieName}=${newThemeName};`)
         window.location.reload()
@@ -58,8 +58,8 @@ export default defineNuxtPlugin((nuxtApp) => {
       // on client, we update the display to avoid hydration mismatch on page refresh
       // there will be some hydration mismatch since the headers sent by the user agent may not be accurate
       if (viewportSize) {
-        const clientWidth = state.value.ssrClientHints.viewportWidth
-        const clientHeight = state.value.ssrClientHints.viewportHeight
+        const clientWidth = state.value.viewportWidth
+        const clientHeight = state.value.viewportHeight
         vuetifyOptions.ssr = typeof clientWidth === 'number'
           ? {
               clientWidth,
@@ -70,19 +70,19 @@ export default defineNuxtPlugin((nuxtApp) => {
 
       // update the theme
       if (prefersColorScheme && prefersColorSchemeOptions)
-        vuetifyOptions.theme.defaultTheme = state.value.ssrClientHints.colorSchemeFromCookie ?? prefersColorSchemeOptions.defaultTheme
+        vuetifyOptions.theme.defaultTheme = state.value.colorSchemeFromCookie ?? prefersColorSchemeOptions.defaultTheme
     })
 
     // update theme logic
     if (prefersColorScheme && prefersColorSchemeOptions) {
-      const themeCookie = state.value.ssrClientHints.colorSchemeCookie
+      const themeCookie = state.value.colorSchemeCookie
       if (themeCookie) {
         nuxtApp.hook('app:beforeMount', () => {
           const vuetify = useNuxtApp().$vuetify
           // update the theme
           const cookieName = prefersColorSchemeOptions.cookieName
           const parseCookieName = `${cookieName}=`
-          const cookieEntry = `${parseCookieName}${state.value.ssrClientHints.colorSchemeFromCookie ?? prefersColorSchemeOptions.defaultTheme};`
+          const cookieEntry = `${parseCookieName}${state.value.colorSchemeFromCookie ?? prefersColorSchemeOptions.defaultTheme};`
           watch(vuetify.theme.global.name, (newThemeName) => {
             document.cookie = themeCookie.replace(cookieEntry, `${cookieName}=${newThemeName};`)
           })

--- a/src/runtime/plugins/vuetify-client-hints.server.ts
+++ b/src/runtime/plugins/vuetify-client-hints.server.ts
@@ -4,7 +4,7 @@ import {
   ssrClientHintsConfiguration,
 } from 'virtual:vuetify-ssr-client-hints-configuration'
 import { reactive } from 'vue'
-import type { ClientHintsRequest, SSRClientHints } from './client-hints'
+import type { SSRClientHints } from './client-hints'
 import { type Browser, parseUserAgent } from './detect-browser'
 import { VuetifyHTTPClientHints } from './client-hints'
 import {
@@ -34,11 +34,9 @@ export default defineNuxtPlugin((nuxtApp) => {
   const clientHintsRequest = collectClientHints(userAgent, ssrClientHintsConfiguration, requestHeaders)
   // 3. write client hints response headers
   writeClientHintsResponseHeaders(clientHintsRequest, ssrClientHintsConfiguration, response)
-  state.value = {
-    ssrClientHints: clientHintsRequest,
-  }
+  state.value = clientHintsRequest
   // 4. send the theme cookie to the client when required
-  state.value.ssrClientHints.colorSchemeCookie = writeThemeCookie(
+  state.value.colorSchemeCookie = writeThemeCookie(
     clientHintsRequest,
     ssrClientHintsConfiguration,
   )
@@ -150,7 +148,7 @@ function lookupClientHints(
   userAgent: ReturnType<typeof parseUserAgent>,
   ssrClientHintsConfiguration: SSRClientHintsConfiguration,
 ) {
-  const features: ClientHintsRequest = {
+  const features: SSRClientHints = {
     firstRequest: true,
     prefersColorSchemeAvailable: false,
     prefersReducedMotionAvailable: false,
@@ -181,7 +179,7 @@ function collectClientHints(
   headers: IncomingHttpHeaders,
 ) {
   // collect client hints
-  const hints: ClientHintsRequest = lookupClientHints(userAgent, ssrClientHintsConfiguration)
+  const hints: SSRClientHints = lookupClientHints(userAgent, ssrClientHintsConfiguration)
 
   if (ssrClientHintsConfiguration.prefersColorScheme) {
     if (ssrClientHintsConfiguration.prefersColorSchemeOptions) {
@@ -277,7 +275,7 @@ function withNuxtAppRendered(callback: () => void) {
 }
 
 function writeClientHintsResponseHeaders(
-  clientHintsRequest: ClientHintsRequest,
+  clientHintsRequest: SSRClientHints,
   ssrClientHintsConfiguration: SSRClientHintsConfiguration,
   response: ServerResponse,
 ) {
@@ -308,7 +306,7 @@ function writeClientHintsResponseHeaders(
 }
 
 function writeThemeCookie(
-  clientHintsRequest: ClientHintsRequest,
+  clientHintsRequest: SSRClientHints,
   ssrClientHintsConfiguration: SSRClientHintsConfiguration,
 ) {
   if (!ssrClientHintsConfiguration.prefersColorScheme || !ssrClientHintsConfiguration.prefersColorSchemeOptions)


### PR DESCRIPTION
Updated internal runtime logic and expose `ssrClientHints` directly without wrapper (keep original runtime types).

Breaking since anyone using the server  runtime `vuetify:ssr-client-hints` hook will need to update.

closes #130