### PR TITLE
fix: import nuxt composables from #imports

### DIFF
--- a/src/runtime/plugins/config.ts
+++ b/src/runtime/plugins/config.ts
@@ -1,6 +1,6 @@
 import { createVuetify } from 'vuetify'
 import { isDev, vuetifyConfiguration } from 'virtual:vuetify-configuration'
-import { useNuxtApp } from '#app'
+import { useNuxtApp } from '#imports'
 
 export async function configureVuetify() {
   const nuxtApp = useNuxtApp()

--- a/src/runtime/plugins/date.ts
+++ b/src/runtime/plugins/date.ts
@@ -1,6 +1,6 @@
 import { adapter, dateConfiguration, enabled, i18n } from 'virtual:vuetify-date-configuration'
 import type { VuetifyOptions } from 'vuetify'
-import { useNuxtApp } from '#app'
+import { useNuxtApp } from '#imports'
 import type { LocaleObject } from '#i18n'
 
 export function configureDate(vuetifyOptions: VuetifyOptions) {

--- a/src/runtime/plugins/i18n.ts
+++ b/src/runtime/plugins/i18n.ts
@@ -3,7 +3,7 @@ import { ref, watch } from 'vue'
 import type { LocaleInstance, LocaleMessages, LocaleOptions, VuetifyOptions } from 'vuetify'
 import type { Locale } from 'vue-i18n'
 import { useI18n } from 'vue-i18n'
-import { useNuxtApp } from '#app'
+import { useNuxtApp } from '#imports'
 
 export function createAdapter(vuetifyOptions: VuetifyOptions) {
   vuetifyOptions.locale = {}

--- a/src/runtime/plugins/vuetify-sync.ts
+++ b/src/runtime/plugins/vuetify-sync.ts
@@ -1,6 +1,5 @@
 import { configureVuetify } from './config'
-import { defineNuxtPlugin } from '#imports'
-import { useNuxtApp } from '#imports'
+import { defineNuxtPlugin, useNuxtApp } from '#imports'
 
 export default defineNuxtPlugin({
   name: 'vuetify:configuration:plugin',

--- a/src/runtime/plugins/vuetify-sync.ts
+++ b/src/runtime/plugins/vuetify-sync.ts
@@ -1,6 +1,6 @@
 import { configureVuetify } from './config'
 import { defineNuxtPlugin } from '#imports'
-import { useNuxtApp } from '#app'
+import { useNuxtApp } from '#imports'
 
 export default defineNuxtPlugin({
   name: 'vuetify:configuration:plugin',

--- a/src/runtime/plugins/vuetify.ts
+++ b/src/runtime/plugins/vuetify.ts
@@ -1,6 +1,5 @@
 import { configureVuetify } from './config'
-import { defineNuxtPlugin } from '#imports'
-import { useNuxtApp } from '#imports'
+import { defineNuxtPlugin, useNuxtApp } from '#imports'
 
 export default defineNuxtPlugin({
   name: 'vuetify:configuration:plugin',

--- a/src/runtime/plugins/vuetify.ts
+++ b/src/runtime/plugins/vuetify.ts
@@ -1,6 +1,6 @@
 import { configureVuetify } from './config'
 import { defineNuxtPlugin } from '#imports'
-import { useNuxtApp } from '#app'
+import { useNuxtApp } from '#imports'
 
 export default defineNuxtPlugin({
   name: 'vuetify:configuration:plugin',

--- a/src/utils/icons.ts
+++ b/src/utils/icons.ts
@@ -154,7 +154,7 @@ export function prepareIcons(
       resolvedIcons.imports.push(`import {${defaultSet === 'fa-svg' ? 'aliases,' : ''}fa} from \'vuetify/iconsets/fa-svg\'`)
       resolvedIcons.imports.push('import { library } from \'@fortawesome/fontawesome-svg-core\'')
       resolvedIcons.imports.push('import { FontAwesomeIcon } from \'@fortawesome/vue-fontawesome\'')
-      resolvedIcons.imports.push('import { useNuxtApp } from \'#app\'')
+      resolvedIcons.imports.push('import { useNuxtApp } from \'#imports\'')
       resolvedIcons.svg.fa = ['useNuxtApp().vueApp.component(\'font-awesome-icon\', FontAwesomeIcon)']
       faSvg.libraries!.forEach(([defaultExport, name, library]) => {
         resolvedIcons.imports.push(`import ${defaultExport ? name : `{${name}}`} from \'${library}\'`)


### PR DESCRIPTION
This is a DX improvement when developing - we can avoid loading the entire barrel file at `#app` by using the new granular imports merged in https://github.com/nuxt/nuxt/pull/23951.