### PR TITLE
feat: add support for Vuetify 3.4

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -6,6 +6,7 @@ import {
   isNuxt3,
   useLogger,
 } from '@nuxt/kit'
+import { getPackageInfo } from 'local-pkg'
 import { version } from '../package.json'
 import type { ModuleOptions } from './types'
 import type { VuetifyNuxtContext } from './utils/config'
@@ -40,6 +41,10 @@ export default defineNuxtModule<ModuleOptions>({
     if (!isNuxt3(nuxt))
       logger.error(`Cannot support nuxt version: ${getNuxtVersion(nuxt)}`)
 
+    const vuetifyPkg = await getPackageInfo('vuetify')
+    const versions = vuetifyPkg?.version?.split('.').map(v => Number.parseInt(v))
+    const vuetify3_4 = versions && versions.length > 1 && versions[0] >= 3 && versions[1] >= 4
+
     const ctx: VuetifyNuxtContext = {
       logger,
       resolver: createResolver(import.meta.url),
@@ -55,6 +60,7 @@ export default defineNuxtModule<ModuleOptions>({
       ssrClientHints: undefined!,
       componentsPromise: undefined!,
       labComponentsPromise: undefined!,
+      vuetify3_4,
     }
 
     await load(options, nuxt, ctx)

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -25,6 +25,7 @@ export interface VuetifyNuxtContext {
   ssrClientHints: ResolvedClientHints
   componentsPromise: Promise<VuetifyComponentsImportMap>
   labComponentsPromise: Promise<VuetifyComponentsImportMap>
+  vuetify3_4?: boolean
 }
 
 export async function loadVuetifyConfiguration<U extends ExternalVuetifyOptions>(

--- a/src/vite/vuetify-date-configuration-plugin.ts
+++ b/src/vite/vuetify-date-configuration-plugin.ts
@@ -50,11 +50,11 @@ export function dateConfiguration() {
   }
 
   function buildAdapter() {
-    if (ctx.dateAdapter === 'custom')
+    if (ctx.dateAdapter === 'custom' || (ctx.dateAdapter === 'vuetify' && ctx.vuetify3_4 === true))
       return ''
 
     if (ctx.dateAdapter === 'vuetify')
-      return ctx.vuetify3_4 === true ? '' : 'options.adapter = VuetifyDateAdapter'
+      return 'options.adapter = VuetifyDateAdapter'
 
     return 'options.adapter = Adapter'
   }

--- a/src/vite/vuetify-date-configuration-plugin.ts
+++ b/src/vite/vuetify-date-configuration-plugin.ts
@@ -27,7 +27,9 @@ export function dateConfiguration() {
         const { adapter: _adapter, ...newDateOptions } = ctx.vuetifyOptions.date ?? {}
 
         const imports = ctx.dateAdapter === 'vuetify'
-          ? 'import { VuetifyDateAdapter } from \'vuetify/labs/date/adapters/vuetify\''
+          ? ctx.vuetify3_4 === true
+            ? ''
+            : 'import { VuetifyDateAdapter } from \'vuetify/labs/date/adapters/vuetify\''
           : ctx.dateAdapter === 'custom'
             ? ''
             : `import Adapter from '@date-io/${ctx.dateAdapter}'`
@@ -52,7 +54,7 @@ export function dateConfiguration() {
       return ''
 
     if (ctx.dateAdapter === 'vuetify')
-      return 'options.adapter = VuetifyDateAdapter'
+      return ctx.vuetify3_4 === true ? '' : 'options.adapter = VuetifyDateAdapter'
 
     return 'options.adapter = Adapter'
   }


### PR DESCRIPTION
This PR includes:
- some/all labs components moved to components
- date options: now there is no need vuetify date adapter to import it (https://github.com/vuetifyjs/vuetify/issues/18593)

`Luxon` date adapter stops working: https://github.com/vuetifyjs/vuetify/issues/18642

closes #147