### PR TITLE
fix: add missing auto-import for `useDate` composable for vuetify < 3.4

### DIFF
--- a/docs/guide/vuetify-composables.md
+++ b/docs/guide/vuetify-composables.md
@@ -12,10 +12,11 @@ No more Vuetify composables manual imports, auto import is enabled by default:
 You can disable auto-import using `moduleOptions.importComposables: false`.
 
 If you are using another composables that collide with the Vuetify ones, enable `moduleOptions.prefixComposables: true` to prefix them with `V`:
-- `useLocale` => `useVLocale`
+- `useDate` => `useVDate`
 - `useDefaults` => `useVDefaults`
-- `useDisplay` => `useVDisplay`
 - `useLayout` => `useVLayout`
+- `useDisplay` => `useVDisplay`
+- `useLocale` => `useVLocale`
 - `useRtl` => `useVRtl`
 - `useTheme` => `useVTheme`
 

--- a/playground/pages/index.vue
+++ b/playground/pages/index.vue
@@ -15,6 +15,9 @@ const value = reactive<{
 const { locales, t } = useI18n()
 const { current } = useLocale()
 const { isRtl } = useRtl()
+const x = useDate()
+// eslint-disable-next-line no-console
+console.log(x.date)
 
 // eslint-disable-next-line n/prefer-global/process
 if (process.client) {

--- a/src/utils/configure-nuxt.ts
+++ b/src/utils/configure-nuxt.ts
@@ -71,13 +71,10 @@ export function configureNuxt(
   }) */
 
   if (importComposables) {
-    const composables: string[] = ['useLocale', 'useDefaults', 'useDisplay', 'useLayout', 'useRtl', 'useTheme']
-    if (ctx.vuetify3_4)
-      composables.push('useDate')
-
+    const composables = ['useDate', 'useLocale', 'useDefaults', 'useDisplay', 'useLayout', 'useRtl', 'useTheme']
     addImports(composables.map(name => ({
       name,
-      from: 'vuetify',
+      from: ctx.vuetify3_4 || name !== 'useDate' ? 'vuetify' : 'vuetify/labs/date',
       as: prefixComposables ? name.replace(/^use/, 'useV') : undefined,
       meta: { docsUrl: `https://vuetifyjs.com/en/api/${toKebabCase(name)}/` },
     })))


### PR DESCRIPTION
`useDate` excluded from Nuxt auto-import:
- Vuetify 3.4+ import from `vuetify`
- Vuetify < 3.4 import from `vuetify/labs/date`: missing import (added in this PR)