### PR TITLE
chore: switch to unbuild with small fix

### DIFF
--- a/build.config.ts
+++ b/build.config.ts
@@ -1,0 +1,78 @@
+import { defineBuildConfig } from 'unbuild'
+
+export default defineBuildConfig([{
+  entries: [
+    { input: 'src/module', outDir: 'dist', ext: 'js', declaration: true },
+    { input: 'src/runtime/', outDir: 'dist/runtime', ext: 'mjs' },
+  ],
+  failOnWarn: false,
+  clean: true,
+  declaration: true,
+  esbuild: {
+    target: 'esnext',
+  },
+  rollup: {
+    emitCJS: true,
+    dts: {
+      respectExternal: true,
+    },
+  },
+  externals: [
+    '@vuetify/loader-shared',
+    'node:child_process',
+    'node:fs',
+    'consola',
+    'destr',
+    'esbuild',
+    'local-pkg',
+    'pathe',
+    'perfect-debounce',
+    'rollup',
+    'upath',
+    'ufo',
+    'unconfig',
+    'unbuild',
+    'vite',
+    'vite-plugin-vuetify',
+    'vuetify',
+    // from module-builder
+    '@nuxt/schema',
+    '@nuxt/schema-edge',
+    '@nuxt/kit',
+    '@nuxt/kit-edge',
+    'nuxt',
+    'nuxt-edge',
+    'nuxt3',
+    'vue',
+    'vue-demi',
+  ],
+}, /* , {
+  entries: [{ input: 'src/module', format: 'cjs', ext: 'cjs' }],
+  clean: false,
+  declaration: true,
+  rollup: {
+    dts: {
+      respectExternal: true,
+    },
+  },
+  emitCJS: false,
+  externals: [
+    '@vuetify/loader-shared',
+    'node:child_process',
+    'node:fs',
+    'consola',
+    'destr',
+    'esbuild',
+    'local-pkg',
+    'pathe',
+    'perfect-debounce',
+    'rollup',
+    'upath',
+    'ufo',
+    'unconfig',
+    'unbuild',
+    'vite',
+    'vite-plugin-vuetify',
+    'vuetify',
+  ],
+} */])

--- a/custom-configuration.d.ts
+++ b/custom-configuration.d.ts
@@ -1,3 +1,3 @@
-import type { ExternalVuetifyOptions } from './dist/module'
+import type { ExternalVuetifyOptions } from './dist/module.js'
 declare function defineVuetifyConfiguration(vuetifyOptions: ExternalVuetifyOptions): ExternalVuetifyOptions;
 export { defineVuetifyConfiguration };

--- a/package.json
+++ b/package.json
@@ -21,8 +21,14 @@
   ],
   "exports": {
     ".": {
-      "types": "./dist/types.d.mts",
-      "default": "./dist/module.mjs"
+      "import": {
+        "types": "./dist/module.d.ts",
+        "default": "./dist/module.js"
+      },
+      "require": {
+        "types": "./dist/module.d.cts",
+        "default": "./dist/module.cjs"
+      }
     },
     "./custom-configuration": {
       "types": "./custom-configuration.d.ts",
@@ -34,7 +40,16 @@
     "./*": "./*"
   },
   "main": "./dist/module.cjs",
-  "types": "./dist/types.d.ts",
+  "module": "./dist/module.js",
+  "types": "./dist/module.d.ts",
+  "typesVersions": {
+    "*": {
+      "*": [
+        "./dist/*",
+        "./*"
+      ]
+    }
+  },
   "files": [
     "dist",
     "*.cjs",
@@ -42,7 +57,8 @@
     "*.mjs"
   ],
   "scripts": {
-    "prepack": "nuxt-module-build prepare && nuxt-module-build build",
+    "xprepack": "nuxt-module-build prepare && nuxt-module-build build",
+    "prepack": "unbuild && node ./scripts/patch-unbuild.mjs",
     "dev": "nuxi dev playground",
     "dev:multiple-json": "MULTIPLE_LANG_FILES=true nuxi dev playground",
     "dev:prepare": "nuxt-module-build --stub && nuxt-module-build prepare && nuxi prepare playground",
@@ -100,11 +116,12 @@
     "rimraf": "^5.0.5",
     "sass": "^1.63.6",
     "typescript": "^5.3.2",
+    "unbuild": "^2.0.0",
     "vite": "^4.5.0",
     "vitest": "^0.34.6",
     "vue-tsc": "^1.8.22"
   },
-  "build": {
+  "xbuild": {
     "externals": [
       "@vuetify/loader-shared",
       "node:child_process",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -114,6 +114,9 @@ importers:
       typescript:
         specifier: ^5.3.2
         version: 5.3.2
+      unbuild:
+        specifier: ^2.0.0
+        version: 2.0.0(sass@1.63.6)(typescript@5.3.2)
       vite:
         specifier: ^4.5.0
         version: 4.5.0(@types/node@18.0.0)(sass@1.63.6)

--- a/scripts/patch-unbuild.mjs
+++ b/scripts/patch-unbuild.mjs
@@ -1,0 +1,10 @@
+import { renameSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+rmSync(resolve('./dist/module.d.mts'))
+renameSync(resolve('./dist/module.mjs'), resolve('dist/module.js'))
+
+const cjsModulePath = resolve('./dist/module.cjs')
+
+const cjsModule = readFileSync(cjsModulePath, 'utf-8')
+writeFileSync(cjsModulePath, cjsModule.replace('module.exports = module$1;', 'exports.default = module$1;'), { encoding: 'utf-8' })

--- a/src/module.ts
+++ b/src/module.ts
@@ -140,3 +140,15 @@ declare module '@nuxt/schema' {
     'vuetify:registerModule': (registerModule: (config: InlineModuleOptions) => void) => HookResult
   }
 }
+
+declare module 'nuxt/schema' {
+  interface NuxtConfig {
+    ['vuetify']?: Partial<ModuleOptions>
+  }
+  interface NuxtOptions {
+    ['vuetify']?: ModuleOptions
+  }
+  interface NuxtHooks {
+    'vuetify:registerModule': (registerModule: (config: InlineModuleOptions) => void) => HookResult
+  }
+}


### PR DESCRIPTION
**NOTE**: this PR will not be merged, it is a test to generate the module using `unbuild` and patching the output with `scripts/patch-unbuild.mjs` before creating the tgz:
- run `pnpm nuxt-module-build prepare && pnpm nuxt-module-build build` after install
- do not run any script with `nuxt-module-build prepare` or `nuxt-module-build --stub` after previous command, not tested in local dev server
- run `pnpm pack` and check the tgz here https://arethetypeswrong.github.io/, you can also run `publint`

This should be used in `module-builder`, we cannot drop node16, we should do it properly: I'm checking required changes when not using type module, with this PR (check current version https://arethetypeswrong.github.io/?p=vuetify-nuxt-module%400.6.7):

![imagen](https://github.com/userquin/vuetify-nuxt-module/assets/6311119/3d57d225-5e6d-4484-ad3c-f3dc626335c2)

We can also drop Node 16 CJS changing the package exports to:
```json
  "exports": {
    ".": {
      "types": "./dist/module.d.ts",
      "default": "./dist/module.js"
    },
  },
  "main": "./dist/module.js",
  "module": "./dist/module.js",
  "types": "./dist/module.d.ts",
```

Tested here https://github.com/userquin/vuetify-nuxt-module-types-check, VS Code seems to work, IntelliJ with same problems with `Bundler`.