### PR TITLE
docs: include iconify icon web component integration

### DIFF
--- a/docs/guide/icons/integrations.md
+++ b/docs/guide/icons/integrations.md
@@ -2,7 +2,8 @@
 
 Vuetify supports custom icon sets using Vue icon libraries. This section is about how to integrate the following icon libraries with `vuetify-nuxt-module`:
 - [unplugin-icons/nuxt](https://github.com/unplugin/unplugin-icons)
-- [Iconify for Vue](https://iconify.design/docs/icon-components/vue/)
+- [Iconify for Vue](https://iconify.design/docs/icon-components/vue/): if you are using SSR, check [this comment](https://github.com/vuetifyjs/vuetify/issues/7821#issuecomment-1876623426) from Iconify author (cyberalien)
+- [Iconify Icon web component](https://iconify.design/docs/iconify-icon/)
 - [Nuxt Icon](https://github.com/nuxt-modules/icon)
 - [Vue Phosphor Icons](https://github.com/phosphor-icons/vue)
 
@@ -19,7 +20,7 @@ You can also use multiple icon sets, check [multiple-icon-sets](/guide/icons/#mu
 
 ## unplugin-icons/nuxt
 
-You can check this [repo using material design icons](https://github.com/userquin/vuetify-nuxt-unplugin-icons-integration), using `unplugin-icons/nuxt` Nuxt module:
+You can check this [repository using material design icons](https://github.com/userquin/vuetify-nuxt-unplugin-icons-integration), using `unplugin-icons/nuxt` Nuxt module:
 - default icon set in [nuxt.config.ts](https://github.com/userquin/vuetify-nuxt-unplugin-icons-integration/blob/main/nuxt.config.ts) configuration file
 - custom icon set in [unplugin-icons/index.ts](https://github.com/userquin/vuetify-nuxt-unplugin-icons-integration/blob/main/unplugin-icons/index.ts) icon set
 - custom icon set registration in [plugins/custom-icons.ts](https://github.com/userquin/vuetify-nuxt-unplugin-icons-integration/blob/main/plugins/custom-icons.ts) plugin
@@ -32,21 +33,40 @@ Not all icons have been included, you will need to review the [unplugin-icons/in
 
 ## Iconify for Vue
 
-You can check an [example in Stackblitz using material design icons](https://stackblitz.com/edit/nuxt-starter-al4k5x):
-- default icon set in [vuetify.config.ts](https://stackblitz.com/edit/nuxt-starter-al4k5x?file=vuetify.config.ts) configuration file
-- custom icon set in [iconify/index.ts](https://stackblitz.com/edit/nuxt-starter-al4k5x?file=iconify%2Findex.ts) icon set
-- custom icon set registration in [plugins/custom-icons.ts](https://stackblitz.com/edit/nuxt-starter-al4k5x?file=plugins%2Fcustom-icons.ts) plugin
-- custom icon component registration in [plugins/custom-icons.ts](https://stackblitz.com/edit/nuxt-starter-al4k5x?file=plugins%2Fcustom-icons.ts) plugin
+You can check this [repository using material design icons](https://github.com/userquin/vuetify-nuxt-iconify-vue-integration):
+- default icon set in [vuetify.config.ts](https://github.com/userquin/vuetify-nuxt-iconify-vue-integration/blob/main/vuetify.config.ts) configuration file
+- custom icon set in [iconify/index.ts](https://github.com/userquin/vuetify-nuxt-iconify-vue-integration/blob/main/iconify/index.ts) icon set
+- custom icon set registration in [plugins/custom-icons.ts](https://github.com/userquin/vuetify-nuxt-iconify-vue-integration/blob/main/plugins/custom-icons.ts) plugin
+- custom icon component registration in [plugins/custom-icons.ts](https://github.com/userquin/vuetify-nuxt-iconify-vue-integration/blob/main/plugins/custom-icons.ts) plugin
+
+You can run this repo in Stackblitz, check the [README file](https://github.com/userquin/vuetify-nuxt-iconify-vue-integration).
 
 ::: warning
-Not all icons have been included, you will need to review the [iconify/index.ts](https://stackblitz.com/edit/nuxt-starter-al4k5x?file=iconify%2Findex.ts) file including the icons you want to use.
+Not all icons have been included, you will need to review the [iconify/index.ts](https://github.com/userquin/vuetify-nuxt-iconify-vue-integration/blob/main/iconify/index.ts) file including the icons you want to use.
 
-Iconify for Vue is client side only, the icons will be rendered only on the client (you will see the icons loaded once the component requests them to the [Iconify API](https://iconify.design/docs/api/)).
+Iconify for Vue is client side only, the icons will be rendered only on the client (you will see the icons loaded once the component requests them to the [Iconify API](https://iconify.design/docs/api/)). If you're using SSR in your Nuxt application, you maybe have hydration mismatch warnings.
+:::
+
+## Iconify Icon Web Component
+
+You can check this [repository using material design icons](https://github.com/userquin/vuetify-nuxt-iconify-icon-integration/):
+- default icon set in [vuetify.config.ts](https://github.com/userquin/vuetify-nuxt-iconify-icon-integration/blob/main/vuetify.config.ts) configuration file
+- custom Vue web component registration [nuxt.config.ts](https://github.com/userquin/vuetify-nuxt-iconify-icon-integration/blob/main/nuxt.config.ts) configuration file, check vue option
+- custom icon set in [iconify/index.ts](https://github.com/userquin/vuetify-nuxt-iconify-icon-integration/blob/main/iconify/index.ts) icon set
+- custom icon set registration in [plugins/custom-icons.ts](https://github.com/userquin/vuetify-nuxt-iconify-icon-integration/blob/main/plugins/custom-icons.ts) plugin
+- custom icon component registration in [plugins/custom-icons.ts](https://github.com/userquin/vuetify-nuxt-iconify-icon-integration/blob/main/iconify/index.ts) plugin (`import 'iconify-icon'`)
+
+You can run this repo in Stackblitz, check the [README file](https://github.com/userquin/vuetify-nuxt-iconify-icon-integration).
+
+::: warning
+Not all icons have been included, you will need to review the [iconify/index.ts](https://github.com/userquin/vuetify-nuxt-iconify-icon-integration/blob/main/iconify/index.ts) file including the icons you want to use.
+
+Iconify Icon Web Component is client side only, the icons will be rendered in the ShadowDOM (you will see the icons loaded once the component requests them to the [Iconify API](https://iconify.design/docs/api/)).
 :::
 
 ## Nuxt Icon
 
-You can check this [repo using material design icons](https://github.com/userquin/vuetify-nuxt-icon-integration):
+You can check this [repository using material design icons](https://github.com/userquin/vuetify-nuxt-icon-integration):
 - default icon set in [nuxt.config.ts](https://github.com/userquin/vuetify-nuxt-icon-integration/blob/main/nuxt.config.ts) configuration file
 - custom icon set in [nuxt-icon-set/common.ts](https://github.com/userquin/vuetify-nuxt-icon-integration/blob/main/nuxt-icon-set/common.ts) icon set
 - custom icon set registration in [plugins/custom-icons.ts](https://github.com/userquin/vuetify-nuxt-icon-integration/blob/main/plugins/custom-icons.ts) plugin
@@ -56,12 +76,14 @@ You can run this repo in Stackblitz, check the [README file](https://github.com/
 
 ## Vue Phosphor Icons
 
-You can check an [example in Stackblitz](https://stackblitz.com/edit/nuxt-starter-cgbvrr):
-- default icon set in [vuetify.config.ts](https://stackblitz.com/edit/nuxt-starter-cgbvrr?file=vuetify.config.ts) configuration file
-- custom icon set in [phosphor/index.ts](https://stackblitz.com/edit/nuxt-starter-cgbvrr?file=phosphor%2Findex.ts) icon set
-- custom icon set registration in [plugins/custom-icons.ts](https://stackblitz.com/edit/nuxt-starter-cgbvrr?file=plugins%2Fcustom-icons.ts) plugin
-- custom icon component registration in [plugins/custom-icons.ts](https://stackblitz.com/edit/nuxt-starter-cgbvrr?file=plugins%2Fcustom-icons.ts) plugin
+You can check this [repository](https://github.com/userquin/vuetify-nuxt-phosphor-vue-integration):
+- default icon set in [vuetify.config.ts](https://github.com/userquin/vuetify-nuxt-phosphor-vue-integration/blob/main/vuetify.config.ts) configuration file
+- custom icon set in [phosphor/index.ts](https://github.com/userquin/vuetify-nuxt-phosphor-vue-integration/blob/main/phosphor/index.ts) icon set
+- custom icon set registration in [plugins/custom-icons.ts](https://github.com/userquin/vuetify-nuxt-phosphor-vue-integration/blob/main/plugins/custom-icons.ts) plugin
+- custom icon component registration in [plugins/custom-icons.ts](https://github.com/userquin/vuetify-nuxt-phosphor-vue-integration/blob/main/plugins/custom-icons.ts) plugin
+
+You can run this repo in Stackblitz, check the [README file](https://github.com/userquin/vuetify-nuxt-phosphor-vue-integration).
 
 ::: warning
-Not all icons have been included, you will need to review the [phosphor/index.ts](https://stackblitz.com/edit/nuxt-starter-cgbvrr?file=phosphor%2Findex.ts) file including the icons you want to use.
+Not all icons have been included, you will need to review the [phosphor/index.ts](https://github.com/userquin/vuetify-nuxt-phosphor-vue-integration/blob/main/phosphor/index.ts) file including the icons you want to use.
 :::

--- a/docs/guide/icons/integrations.md
+++ b/docs/guide/icons/integrations.md
@@ -51,7 +51,7 @@ Iconify for Vue is client side only, the icons will be rendered only on the clie
 
 You can check this [repository using material design icons](https://github.com/userquin/vuetify-nuxt-iconify-icon-integration/):
 - default icon set in [vuetify.config.ts](https://github.com/userquin/vuetify-nuxt-iconify-icon-integration/blob/main/vuetify.config.ts) configuration file
-- custom Vue web component registration [nuxt.config.ts](https://github.com/userquin/vuetify-nuxt-iconify-icon-integration/blob/main/nuxt.config.ts) configuration file, check vue option
+- custom Vue web component registration in [nuxt.config.ts](https://github.com/userquin/vuetify-nuxt-iconify-icon-integration/blob/main/nuxt.config.ts) configuration file, check vue option
 - custom icon set in [iconify/index.ts](https://github.com/userquin/vuetify-nuxt-iconify-icon-integration/blob/main/iconify/index.ts) icon set
 - custom icon set registration in [plugins/custom-icons.ts](https://github.com/userquin/vuetify-nuxt-iconify-icon-integration/blob/main/plugins/custom-icons.ts) plugin
 - custom icon component registration in [plugins/custom-icons.ts](https://github.com/userquin/vuetify-nuxt-iconify-icon-integration/blob/main/iconify/index.ts) plugin (`import 'iconify-icon'`)


### PR DESCRIPTION
This PR also updates all integration links to the corresponding GH repos: created icnofy for vue and phosphor vue repositories