### PR TITLE
feat!: change main vuetify plugins logic

### DIFF
--- a/playground/middleware/1.vuetify.global.ts
+++ b/playground/middleware/1.vuetify.global.ts
@@ -1,0 +1,4 @@
+export default defineNuxtRouteMiddleware((to) => {
+  // eslint-disable-next-line no-console
+  console.log('global middleware', to.path, useNuxtApp().$vuetify)
+})

--- a/playground/middleware/vuetify.ts
+++ b/playground/middleware/vuetify.ts
@@ -1,0 +1,4 @@
+export default defineNuxtRouteMiddleware((to) => {
+  // eslint-disable-next-line no-console
+  console.log('middleware', to.path, useNuxtApp().$vuetify)
+})

--- a/playground/pages/index.vue
+++ b/playground/pages/index.vue
@@ -3,6 +3,10 @@
 import { ssrClientHintsConfiguration } from 'virtual:vuetify-ssr-client-hints-configuration'
 import prependAvatar from '~/assets/logo.svg'
 
+definePageMeta({
+  middleware: 'vuetify',
+})
+
 const value = reactive<{
   name1?: string
   name2?: string

--- a/src/runtime/plugins/vuetify-sync.ts
+++ b/src/runtime/plugins/vuetify-sync.ts
@@ -1,6 +1,6 @@
 import type { createVuetify } from 'vuetify'
 import { configureVuetify } from './config'
-import { defineNuxtPlugin, useNuxtApp } from '#imports'
+import { defineNuxtPlugin } from '#imports'
 import type { Plugin } from '#app'
 
 const plugin: Plugin<{
@@ -8,10 +8,12 @@ const plugin: Plugin<{
 }> = defineNuxtPlugin({
   name: 'vuetify:configuration:plugin',
   enforce: 'post',
-  // i18n runtime plugin is async
+  // @ts-expect-error i18n plugin missing on build time
+  dependsOn: ['i18n:plugin'],
+  // i18n runtime plugin can be async
   parallel: false,
-  setup() {
-    useNuxtApp().hook('app:created', configureVuetify)
+  async setup() {
+    await configureVuetify()
   },
 })
 

--- a/src/runtime/plugins/vuetify.ts
+++ b/src/runtime/plugins/vuetify.ts
@@ -1,6 +1,6 @@
 import type { createVuetify } from 'vuetify'
 import { configureVuetify } from './config'
-import { defineNuxtPlugin, useNuxtApp } from '#imports'
+import { defineNuxtPlugin } from '#imports'
 import type { Plugin } from '#app'
 
 const plugin: Plugin<{
@@ -8,8 +8,8 @@ const plugin: Plugin<{
 }> = defineNuxtPlugin({
   name: 'vuetify:configuration:plugin',
   enforce: 'post',
-  setup() {
-    useNuxtApp().hook('app:created', configureVuetify)
+  async setup() {
+    await configureVuetify()
   },
 })
 


### PR DESCRIPTION
This PR will configure Vuetify plugin without `app:create` Nuxt  hook: will allow to use `useNuxtApp().$vuetify` also in middlewares.

I'm going to request (and maybe implement) a new Nuxt feature to allow use any nuxt vuetify runtime plugin in parallel: https://github.com/nuxt/nuxt/issues/25141

releated #179 This PR will not resolve the issue since it is a problem releated to storybook, tested on my local with local tgz from this PR and still missing styles and icons

closes #87