### PR TITLE
fix: vuetify nuxt plugins templates must be statically analysable

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -109,7 +109,7 @@ export interface ModuleRuntimeHooks {
 }
 
 declare module '#app' {
-  interface RuntimeNuxtHooks {
+  interface ModuleRuntimeHooks {
     'vuetify:configuration': (options: {
       isDev: boolean
       vuetifyOptions: VuetifyOptions

--- a/src/utils/configure-nuxt.ts
+++ b/src/utils/configure-nuxt.ts
@@ -3,7 +3,7 @@ import { addImports, addPlugin, extendWebpackConfig } from '@nuxt/kit'
 import { transformAssetUrls } from 'vite-plugin-vuetify'
 import defu from 'defu'
 import type { VuetifyNuxtContext } from './config'
-import { addVuetifyPluginTemplates } from './vuetify-plugin-template'
+import { addVuetifyNuxtPlugins } from './vuetify-nuxt-plugins'
 import { normalizeTransformAssetUrls, toKebabCase } from './index'
 
 export function configureNuxt(
@@ -121,5 +121,5 @@ export function configureNuxt(
     }
   }
 
-  addVuetifyPluginTemplates(nuxt, ctx)
+  addVuetifyNuxtPlugins(nuxt, ctx)
 }

--- a/src/utils/vuetify-nuxt-plugins.ts
+++ b/src/utils/vuetify-nuxt-plugins.ts
@@ -2,28 +2,28 @@ import { addPluginTemplate } from '@nuxt/kit'
 import type { Nuxt } from '@nuxt/schema'
 import type { VuetifyNuxtContext } from './config'
 
-export function addVuetifyPluginTemplates(
+export function addVuetifyNuxtPlugins(
   nuxt: Nuxt,
   ctx: VuetifyNuxtContext,
 ) {
-  addVuetifyPlugin(nuxt, ctx, true)
-  addVuetifyPlugin(nuxt, ctx, false)
+  addVuetifyNuxtPlugin(nuxt, ctx, 'client')
+  addVuetifyNuxtPlugin(nuxt, ctx, 'server')
 }
 
-function addVuetifyPlugin(
+function addVuetifyNuxtPlugin(
   nuxt: Nuxt,
   ctx: VuetifyNuxtContext,
-  client: boolean,
+  mode: 'client' | 'server',
 ) {
   addPluginTemplate({
-    filename: `vuetify-nuxt-plugin.${client ? 'client' : 'server'}.mjs`,
-    name: `vuetify:nuxt:${client ? 'client' : 'server'}:plugin`,
+    filename: `vuetify-nuxt-plugin.${mode}.mjs`,
+    name: `vuetify:nuxt:${mode}:plugin`,
     write: false,
-    mode: client ? 'client' : 'server',
+    mode,
     getContents() {
       const dependsOn = ['vuetify:icons:plugin'] as import('#app').NuxtAppLiterals['pluginName'][]
       if (ctx.ssrClientHints.enabled) {
-        if (client)
+        if (mode === 'client')
           // @ts-expect-error missing at build time
           dependsOn.push('vuetify:client-hints:client:plugin')
         else
@@ -50,7 +50,7 @@ import { isDev, vuetifyConfiguration } from 'virtual:vuetify-configuration'
 import { createVuetify } from 'vuetify'
 
 export default defineNuxtPlugin({
-  name: 'vuetify:nuxt:${client ? 'client' : 'server'}:plugin',
+  name: 'vuetify:nuxt:${mode}:plugin',
   order: 25,
   dependsOn: ${JSON.stringify(dependsOn)},
   parallel: true,

--- a/src/utils/vuetify-plugin-template.ts
+++ b/src/utils/vuetify-plugin-template.ts
@@ -1,7 +1,6 @@
 import { addPluginTemplate } from '@nuxt/kit'
 import type { Nuxt } from '@nuxt/schema'
 import type { VuetifyNuxtContext } from './config'
-import type { PluginMeta } from '#app'
 
 export function addVuetifyPluginTemplates(
   nuxt: Nuxt,
@@ -18,10 +17,10 @@ function addVuetifyPlugin(
 ) {
   addPluginTemplate({
     filename: `vuetify-nuxt-plugin.${client ? 'client' : 'server'}.mjs`,
-    write: true,
+    write: false,
     mode: client ? 'client' : 'server',
     getContents() {
-      const dependsOn: PluginMeta['dependsOn'] = ['vuetify:icons:plugin']
+      const dependsOn = ['vuetify:icons:plugin'] as import('#app').NuxtAppLiterals['pluginName'][]
       if (ctx.ssrClientHints.enabled) {
         if (client)
           // @ts-expect-error missing at build time

--- a/src/utils/vuetify-plugin-template.ts
+++ b/src/utils/vuetify-plugin-template.ts
@@ -1,0 +1,72 @@
+import { addPluginTemplate } from '@nuxt/kit'
+import type { Nuxt } from '@nuxt/schema'
+import type { VuetifyNuxtContext } from './config'
+import type { PluginMeta } from '#app'
+
+export function addVuetifyPluginTemplates(
+  nuxt: Nuxt,
+  ctx: VuetifyNuxtContext,
+) {
+  addVuetifyPlugin(nuxt, ctx, true)
+  addVuetifyPlugin(nuxt, ctx, false)
+}
+
+function addVuetifyPlugin(
+  nuxt: Nuxt,
+  ctx: VuetifyNuxtContext,
+  client: boolean,
+) {
+  addPluginTemplate({
+    filename: `vuetify-nuxt-plugin.${client ? 'client' : 'server'}.mjs`,
+    write: true,
+    mode: client ? 'client' : 'server',
+    getContents() {
+      const dependsOn: PluginMeta['dependsOn'] = ['vuetify:icons:plugin']
+      if (ctx.ssrClientHints.enabled) {
+        if (client)
+          // @ts-expect-error missing at build time
+          dependsOn.push('vuetify:client-hints:client:plugin')
+        else
+          // @ts-expect-error missing at build time
+          dependsOn.push('vuetify:client-hints:server:plugin')
+      }
+      if (ctx.i18n) {
+        // @ts-expect-error missing at build time
+        dependsOn.push('vuetify:i18n:plugin')
+      }
+      if (nuxt.options.dev || ctx.dateAdapter) {
+        if (ctx.i18n) {
+          // @ts-expect-error missing at build time
+          dependsOn.push('vuetify:date-i18n:plugin')
+        }
+        else {
+          // @ts-expect-error missing at build time
+          dependsOn.push('vuetify:date:plugin')
+        }
+      }
+      return `
+import { defineNuxtPlugin } from '#imports'
+import { isDev, vuetifyConfiguration } from 'virtual:vuetify-configuration'
+import { createVuetify } from 'vuetify'
+
+export default defineNuxtPlugin({
+  name: 'vuetify:nuxt:plugin',
+  order: 25,
+  dependsOn: ${JSON.stringify(dependsOn)},
+  parallel: true,
+  async setup(nuxtApp) {
+    const vuetifyOptions = vuetifyConfiguration()
+    await nuxtApp.hooks.callHook('vuetify:configuration', { isDev, vuetifyOptions })
+    await nuxtApp.hooks.callHook('vuetify:before-create', { isDev, vuetifyOptions })
+    const vuetify = createVuetify(vuetifyOptions)
+    nuxtApp.vueApp.use(vuetify)
+    nuxtApp.provide('vuetify', vuetify)
+    await nuxtApp.hooks.callHook('vuetify:ready', vuetify)
+    if (process.client)
+      isDev && console.log('Vuetify 3 initialized', vuetify)
+  },
+})
+`
+    },
+  })
+}

--- a/src/utils/vuetify-plugin-template.ts
+++ b/src/utils/vuetify-plugin-template.ts
@@ -17,6 +17,7 @@ function addVuetifyPlugin(
 ) {
   addPluginTemplate({
     filename: `vuetify-nuxt-plugin.${client ? 'client' : 'server'}.mjs`,
+    name: `vuetify:nuxt:${client ? 'client' : 'server'}:plugin`,
     write: false,
     mode: client ? 'client' : 'server',
     getContents() {
@@ -49,7 +50,7 @@ import { isDev, vuetifyConfiguration } from 'virtual:vuetify-configuration'
 import { createVuetify } from 'vuetify'
 
 export default defineNuxtPlugin({
-  name: 'vuetify:nuxt:plugin',
+  name: 'vuetify:nuxt:${client ? 'client' : 'server'}:plugin',
   order: 25,
   dependsOn: ${JSON.stringify(dependsOn)},
   parallel: true,


### PR DESCRIPTION
This PR splits Vuetify Nuxt plugin template in client and server plugin templates, moving `dependsOn` inside the `getContents` callback.