### PR TITLE
Fixing the tests plugin error

### DIFF
--- a/playground/assets/custom-vuetify.scss
+++ b/playground/assets/custom-vuetify.scss
@@ -1,0 +1,3 @@
+@use 'vuetify/settings' with (
+  $button-font-weight: 700,
+);

--- a/playground/assets/settings.scss
+++ b/playground/assets/settings.scss
@@ -1,5 +1,5 @@
 /* DON'T USE @use here */
-@forward 'vuetify/settings' with (
-  $utilities: false,
-  $button-height: 40px,
+@use 'vuetify/settings' with (
+  $button-height: 80px,
+  $button-font-weight: 700,
 );

--- a/playground/assets/settings.scss
+++ b/playground/assets/settings.scss
@@ -1,5 +1,5 @@
 /* DON'T USE @use here */
 @forward 'vuetify/settings' with (
-  $button-height: 80px,
-  $button-font-weight: 700,
+  $utilities: false,
+  $button-height: 40px,
 );

--- a/playground/assets/settings.scss
+++ b/playground/assets/settings.scss
@@ -1,5 +1,5 @@
 /* DON'T USE @use here */
-@use 'vuetify/settings' with (
+@forward 'vuetify/settings' with (
   $button-height: 80px,
   $button-font-weight: 700,
 );

--- a/playground/nuxt.config.ts
+++ b/playground/nuxt.config.ts
@@ -48,7 +48,7 @@ export default defineNuxtConfig({
         },
         viewportSize: true,
       },
-      styles: { configFile: 'assets/settings.scss' },
+      styles: { configFile: 'assets/custom-vuetify.scss' },
     },
   },
   vite: {

--- a/playground/nuxt.config.ts
+++ b/playground/nuxt.config.ts
@@ -48,7 +48,7 @@ export default defineNuxtConfig({
         },
         viewportSize: true,
       },
-      // styles: { configFile: 'assets/settings.scss' },
+      styles: { configFile: 'assets/settings.scss' },
     },
   },
   vite: {

--- a/playground/nuxt.config.ts
+++ b/playground/nuxt.config.ts
@@ -48,7 +48,7 @@ export default defineNuxtConfig({
         },
         viewportSize: true,
       },
-      styles: { configFile: 'assets/custom-vuetify.scss' },
+      // styles: { configFile: 'assets/custom-vuetify.scss' },
     },
   },
   vite: {

--- a/src/vite/vuetify-styles-plugin.ts
+++ b/src/vite/vuetify-styles-plugin.ts
@@ -11,7 +11,7 @@ function isSubdir(root: string, test: string) {
 
 export function vuetifyStylesPlugin(
   options: Options,
-  logger: ReturnType<typeof import('@nuxt/kit')['useLogger']>,
+  _logger: ReturnType<typeof import('@nuxt/kit')['useLogger']>,
 ) {
   const vuetifyBase = resolveVuetifyBase()
 
@@ -80,6 +80,9 @@ export function vuetifyStylesPlugin(
         const file = /^\/@fs\/plugin-vuetify\/lib\/(.*?)(\?.*)?$/.exec(id)![1]
         return tempFiles.get(file)
       }
+
+      if (id.includes('plugin-vuetify/lib'))
+        return ''
     },
   }
 }

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -2,7 +2,7 @@ import { fileURLToPath } from 'node:url'
 import { describe, expect, it } from 'vitest'
 import { $fetch, setup } from '@nuxt/test-utils'
 
-describe.skip('ssr', async () => {
+describe('ssr', async () => {
   await setup({
     rootDir: fileURLToPath(new URL('./fixtures/basic', import.meta.url)),
   })
@@ -10,6 +10,6 @@ describe.skip('ssr', async () => {
   it('renders the index page', async () => {
     // Get response to a server-rendered page with `$fetch`.
     const html = await $fetch('/')
-    expect(html).toContain('<div>basic</div>')
+    expect(html).contain('v-application')
   })
 })

--- a/test/fixtures/basic/app.vue
+++ b/test/fixtures/basic/app.vue
@@ -1,3 +1,3 @@
 <template>
-  <div>basic</div>
+  <v-app>basic</v-app>
 </template>

--- a/test/fixtures/sass/app.vue
+++ b/test/fixtures/sass/app.vue
@@ -1,0 +1,3 @@
+<template>
+  <v-app>basic</v-app>
+</template>

--- a/test/fixtures/sass/app.vue
+++ b/test/fixtures/sass/app.vue
@@ -1,3 +1,5 @@
 <template>
-  <v-app>basic</v-app>
+  <v-app>
+    <v-btn>Hi</v-btn>
+  </v-app>
 </template>

--- a/test/fixtures/sass/nuxt.config.ts
+++ b/test/fixtures/sass/nuxt.config.ts
@@ -1,0 +1,16 @@
+import { fileURLToPath } from 'node:url'
+import MyModule from '../../../src/module'
+
+export default defineNuxtConfig({
+  modules: [MyModule],
+  vuetify: {
+    moduleOptions: {
+      /* other module options */
+      styles: {
+        configFile: fileURLToPath(
+          new URL('./vuetify-settings.scss', import.meta.url),
+        ),
+      },
+    },
+  },
+})

--- a/test/fixtures/sass/package.json
+++ b/test/fixtures/sass/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "sass",
+  "type": "module",
+  "private": true
+}

--- a/test/fixtures/sass/vuetify-settings.scss
+++ b/test/fixtures/sass/vuetify-settings.scss
@@ -1,18 +1,4 @@
-@use "sass:map";
-
-$font-family: 'Open Sans', sans-serif;
-
-// 👉 Shadow opacities
-$shadow-key-umbra-opacity-custom: var(--v-shadow-key-umbra-opacity, rgba(0 0 0 / 10%)) !default;
-$shadow-key-penumbra-opacity-custom: var(--v-shadow-key-penumbra-opacity, rgba(0 0 0 / 1%)) !default;
-$shadow-key-ambient-opacity-custom: var(--v-shadow-key-ambient-opacity, rgba(0 0 0 / 10%)) !default;
-
 @use 'vuetify/settings' with (
-  $body-font-family: $font-family,
-  $heading-font-family: $font-family,
-
-  // 👉 Shadow opacity
-  $shadow-key-umbra-opacity: $shadow-key-umbra-opacity-custom,
-  $shadow-key-penumbra-opacity: $shadow-key-penumbra-opacity-custom,
-  $shadow-key-ambient-opacity: $shadow-key-ambient-opacity-custom,
+  $button-height: 80px,
+  $button-font-weight: 700,
 );

--- a/test/fixtures/sass/vuetify-settings.scss
+++ b/test/fixtures/sass/vuetify-settings.scss
@@ -1,0 +1,18 @@
+@use "sass:map";
+
+$font-family: 'Open Sans', sans-serif;
+
+// 👉 Shadow opacities
+$shadow-key-umbra-opacity-custom: var(--v-shadow-key-umbra-opacity, rgba(0 0 0 / 10%)) !default;
+$shadow-key-penumbra-opacity-custom: var(--v-shadow-key-penumbra-opacity, rgba(0 0 0 / 1%)) !default;
+$shadow-key-ambient-opacity-custom: var(--v-shadow-key-ambient-opacity, rgba(0 0 0 / 10%)) !default;
+
+@use 'vuetify/settings' with (
+  $body-font-family: $font-family,
+  $heading-font-family: $font-family,
+
+  // 👉 Shadow opacity
+  $shadow-key-umbra-opacity: $shadow-key-umbra-opacity-custom,
+  $shadow-key-penumbra-opacity: $shadow-key-penumbra-opacity-custom,
+  $shadow-key-ambient-opacity: $shadow-key-ambient-opacity-custom,
+);

--- a/test/sass.test.ts
+++ b/test/sass.test.ts
@@ -10,6 +10,6 @@ describe('sass', async () => {
   it('renders the index page', async () => {
     // Get response to a server-rendered page with `$fetch`.
     const html = await $fetch('/')
-    expect(html).toContain('<div>basic</div>')
+    expect(html).toContain('Hi')
   })
 })

--- a/test/sass.test.ts
+++ b/test/sass.test.ts
@@ -1,0 +1,15 @@
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+import { $fetch, setup } from '@nuxt/test-utils'
+
+describe('sass', async () => {
+  await setup({
+    rootDir: fileURLToPath(new URL('./fixtures/sass', import.meta.url)),
+  })
+
+  it('renders the index page', async () => {
+    // Get response to a server-rendered page with `$fetch`.
+    const html = await $fetch('/')
+    expect(html).toContain('<div>basic</div>')
+  })
+})


### PR DESCRIPTION
Fixing the tests plugin error

Changes made in this pull request:
- Creating test to detect error
- Fixing error by adding `plugin-vuetify/lib` checker

Fixed error:
```
FAIL  test/sass.test.ts > sass
Error: Could not load /plugin-vuetify/lib/components/VApp/VApp.sass?inline&used: ENOENT: no such file or directory, open '/plugin-vuetify/lib/components/VApp/VApp.sass?inline&used'
```
All tests passed now:
```
✓ test/detect-browser.test.ts (10)
 ✓ test/basic.test.ts (1) 10065ms
 ✓ test/sass.test.ts (1) 12979ms

 Test Files  3 passed (3)
      Tests  12 passed (12)
   Start at  14:32:47
   Duration  13.72s (transform 88ms, setup 0ms, collect 740ms, tests 23.05s, environment 1ms, prepare 292ms)
```

closes #191