### PR TITLE
fix!: transpile vuetify, runtime dir, vuetify plugin and virtual modules

### DIFF
--- a/src/vite/constants.ts
+++ b/src/vite/constants.ts
@@ -1,7 +1,7 @@
 export const VIRTUAL_VUETIFY_CONFIGURATION = 'virtual:vuetify-configuration'
 // TODO: ask Daniel Roe, I guess it is some internal nuxt module that shouldn't intercept this
 // Nuxt DevTools doesn't show the virtual when using Vite's default but it does when removing virtual: prefix
-// const RESOLVED_VIRTUAL_VUETIFY_CONFIGURATION = `\0${VIRTUAL_VUETIFY_CONFIGURATION}`
+// export const RESOLVED_VIRTUAL_VUETIFY_CONFIGURATION = `\0${VIRTUAL_VUETIFY_CONFIGURATION}`
 export const RESOLVED_VIRTUAL_VUETIFY_CONFIGURATION = `/@nuxt-vuetify-configuration/${VIRTUAL_VUETIFY_CONFIGURATION.slice('virtual:'.length)}`
 
 export const VIRTUAL_VUETIFY_DATE_CONFIGURATION = 'virtual:vuetify-date-configuration'


### PR DESCRIPTION
This PR will transpile:
- vuetify
- vuetify nuxt module runtime folder
- vuetify nuxt plugins (client and server)
- all vuetify vite virtual configuration modules: check [nuxt:imports-transform](https://github.com/nuxt/nuxt/blob/main/packages/nuxt/src/imports/transform.ts)

When importing stuff from `#imports`  from vuetify virtual condiguration modules Nuxt not transforming the import and so will break the application:
```shell
[nuxt] `#imports` should be transformed with real imports. There seems to be something wrong with the imports plugin.
```

closes #200