### PR TITLE
fix!: opt in to `import.meta.*` properties

### DIFF
--- a/playground/pages/index.vue
+++ b/playground/pages/index.vue
@@ -24,7 +24,7 @@ const x = useDate()
 console.log(x.date)
 
 // eslint-disable-next-line n/prefer-global/process
-if (process.client) {
+if (import.meta.client) {
   // eslint-disable-next-line no-console
   console.log(useNuxtApp().$vuetify.icons)
 }

--- a/playground/plugins/vuetify.ts
+++ b/playground/plugins/vuetify.ts
@@ -1,7 +1,7 @@
 export default defineNuxtPlugin((nuxtApp) => {
   nuxtApp.hook('vuetify:before-create', ({ isDev, vuetifyOptions }) => {
     // eslint-disable-next-line n/prefer-global/process
-    if (process.client && isDev) {
+    if (import.meta.client && isDev) {
       // eslint-disable-next-line no-console
       console.log('vuetify:plugin:hook', vuetifyOptions)
     }

--- a/src/module.ts
+++ b/src/module.ts
@@ -31,7 +31,7 @@ export default defineNuxtModule<VuetifyModuleOptions>({
     name: 'vuetify-nuxt-module',
     configKey: 'vuetify',
     compatibility: {
-      nuxt: '^3.6.5',
+      nuxt: '^3.9.0',
       bridge: false,
     },
     version,

--- a/src/utils/vuetify-nuxt-plugins.ts
+++ b/src/utils/vuetify-nuxt-plugins.ts
@@ -62,7 +62,7 @@ export default defineNuxtPlugin({
     nuxtApp.vueApp.use(vuetify)
     nuxtApp.provide('vuetify', vuetify)
     await nuxtApp.hooks.callHook('vuetify:ready', vuetify)
-    if (process.client)
+    if (import.meta.client)
       isDev && console.log('Vuetify 3 initialized', vuetify)
   },
 })


### PR DESCRIPTION
This is a very early PR to make this module compatible with [changes we expect to release in Nuxt v5](https://github.com/nuxt/nuxt/issues/25323).

In [Nuxt v3.7.0](https://github.com/nuxt/nuxt/releases/tag/v3.7.0) we added support for `import.meta.*` (see [original PR](https://github.com/nuxt/nuxt/pull/22428)) and we've been gradually updating docs and moving across from the old `process.*` patterned variables.

As I'm sure you're aware, these variables are replaced at build-time and enable tree-shaking in bundled code.
This change affects _runtime_ code (that is, that is processed by the Nuxt bundler, like vite or webpack) rather than code running in Node. So it really doesn't matter what the string is, but it makes more sense in an ESM-world to use `import.meta` rather than `process`.

(It might be worth updating the module compatibility as well to indicate it needs to have Nuxt v3.7.0+, but I'll leave that with you if you think this is a good approach.)