### PR TITLE
fix: adopt forward-compatible approach to `builder:watch`

### DIFF
--- a/src/utils/loader.ts
+++ b/src/utils/loader.ts
@@ -1,3 +1,4 @@
+import { relative, resolve } from 'node:path'
 import type { Nuxt } from '@nuxt/schema'
 import defu from 'defu'
 import { debounce } from 'perfect-debounce'
@@ -105,6 +106,7 @@ export function registerWatcher(options: VuetifyModuleOptions, nuxt: Nuxt, ctx: 
     let pageReload: (() => Promise<void>) | undefined
 
     nuxt.hooks.hook('builder:watch', (_event, path) => {
+      path = relative(nuxt.options.srcDir, resolve(nuxt.options.srcDir, path))
       if (!pageReload && ctx.vuetifyFilesToWatch.includes(path))
         return nuxt.callHook('restart')
     })


### PR DESCRIPTION
We are planning to move to [emitting absolute paths in `builder:watch` in Nuxt v4](https://github.com/nuxt/nuxt/issues/25339). You can see a little more about the history in the PR linked in that issue.

This PR is an attempt to use a forward/backward compatible approach, namely resolving the path to ensure it's absolute, then making it relative so your existing code will continue to work.

This should be safe to merge as is, but do let me know if you have any concerns about this approach.

