### PR TITLE
docs: update link to Nuxt i18n docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@
 - 😃 **Icon Fonts**: configure the [icon font](https://vuetifyjs.com/en/features/icon-fonts/) you want to use, the module will automatically import it for you using CDN or local dependencies
 - 🎭 **SVG Icons**: ready to use [@mdi/js](https://www.npmjs.com/package/@mdi/js) and [@fortawesome/vue-fontawesome](https://www.npmjs.com/package/@fortawesome/vue-fontawesome) SVG icons packs
 - 📦 **Multiple Icon Sets**: register [multiple icon sets](https://vuetifyjs.com/en/features/icon-fonts/#multiple-icon-sets)
-- 🌍 **I18n Ready**: install [@nuxtjs/i18n](https://v8.i18n.nuxtjs.org/) Nuxt module, and you're ready to use Vuetify [internationalization](https://vuetifyjs.com/en/features/internationalization/) features
+- 🌍 **I18n Ready**: install [@nuxtjs/i18n](https://i18n.nuxtjs.org/) Nuxt module, and you're ready to use Vuetify [internationalization](https://vuetifyjs.com/en/features/internationalization/) features
 - 📆 **Date Components**: use Vuetify components [that require date functionality](https://vuetifyjs.com/en/features/dates/) installing and configuring one of the [@date-io](https://github.com/dmtrKovalenko/date-io#projects) adapters
 - 💬 **Auto-Import Vuetify Locale Messages**: add [Vuetify Locale Messages](https://vuetifyjs.com/en/features/internationalization/#getting-started) adding just the locales you want to use, no more imports needed
 - ⚙️ **Auto-Import Vuetify Composables**: you don't need to import Vuetify composables manually, they are automatically imported for you

--- a/docs/guide/i18n.md
+++ b/docs/guide/i18n.md
@@ -6,10 +6,10 @@ outline: deep
 
 ::: warning
 
-From version `v0.8.0`, this module requires latest [@nuxtjs/i18n](https://v8.i18n.nuxtjs.org/) Nuxt module: `^8.0.0`.
+From version `v0.8.0`, this module requires latest [@nuxtjs/i18n](https://i18n.nuxtjs.org/) Nuxt module: `^8.0.0`.
 :::
 
-Install and configure [@nuxtjs/i18n](https://v8.i18n.nuxtjs.org/) Nuxt module, and you're ready to use Vuetify [internationalization](https://vuetifyjs.com/en/features/internationalization/) features.
+Install and configure [@nuxtjs/i18n](https://i18n.nuxtjs.org/) Nuxt module, and you're ready to use Vuetify [internationalization](https://vuetifyjs.com/en/features/internationalization/) features.
 
 ::: tip
 NOTE: You need to provide the translations by yourself. The module won't provide them automatically. You can include the translations from `vuetify/locale` or add your own ones.


### PR DESCRIPTION
Updates the links to point to the latest docs, we should probably redirect the previous URL to the latest docs as well.