### PR TITLE
docs: use new `nuxi module add` command in installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,13 +52,7 @@
 > Requires Vite, will not work with Webpack
 
 ```bash
-npm i vuetify-nuxt-module -D 
-
-# yarn 
-yarn add vuetify-nuxt-module -D
-
-# pnpm 
-pnpm add vuetify-nuxt-module -D
+npx nuxi@latest module add vuetify-nuxt-module
 ```
 
 [![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/userquin/vuetify-nuxt-module)

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -23,18 +23,9 @@ You can open the vuetify-nuxt-module GitHub repo in StackBlitz to start playing 
 ::: warning
 Requires Vite, will not work with Webpack
 :::
-
-::: code-group
-  ```bash [pnpm]
-  pnpm add -D vuetify-nuxt-module
-  ```
-  ```bash [yarn]
-  yarn add -D vuetify-nuxt-module
-  ```
-  ```bash [npm]
-  npm install -D vuetify-nuxt-module
-  ```
-:::
+```bash
+npx nuxi@latest module add vuetify-nuxt-module
+```
 
 ## Usage
 


### PR DESCRIPTION

This updates the documentation to use the [`nuxi module add` command](https://github.com/nuxt/cli/pull/197) which should simplify docs a bit and also improve user experience as there's no need to add to `nuxt.config` manually.

It's documented [here](https://nuxt.com/docs/api/commands/module#nuxi-module-add).

I may have missed a few spots in the documentation as I'm doing this across the modules ecosystem assisted by the power of regular expressions ✨, so I'd appreciate a review 🙏
