### PR TITLE
fix: should always include styles

### DIFF
--- a/playground/pages/index.vue
+++ b/playground/pages/index.vue
@@ -23,7 +23,6 @@ const x = useDate()
 // eslint-disable-next-line no-console
 console.log(x.date)
 
-// eslint-disable-next-line n/prefer-global/process
 if (import.meta.client) {
   // eslint-disable-next-line no-console
   console.log(useNuxtApp().$vuetify.icons)

--- a/src/utils/configure-nuxt.ts
+++ b/src/utils/configure-nuxt.ts
@@ -35,12 +35,9 @@ export function configureNuxt(
     nuxt.options.imports.transform.include.push(new RegExp(`${virtual}$`))
 
   nuxt.options.css ??= []
-  if (typeof styles === 'string' && ['sass', 'expose'].includes(styles))
-    nuxt.options.css.unshift('vuetify/styles/main.sass')
-  else if (styles === true)
-    nuxt.options.css.unshift('vuetify/styles')
-  else if (typeof styles === 'object' && typeof styles?.configFile === 'string')
-    nuxt.options.css.unshift(styles.configFile)
+
+  //should always add vuetify/styles.
+  nuxt.options.css.unshift('vuetify/styles')
 
   if (includeTransformAssetsUrls && typeof nuxt.options.vite.vue?.template?.transformAssetUrls === 'undefined') {
     nuxt.options.vite.vue ??= {}

--- a/src/utils/configure-nuxt.ts
+++ b/src/utils/configure-nuxt.ts
@@ -16,7 +16,6 @@ export function configureNuxt(
   const {
     importComposables,
     prefixComposables,
-    styles,
     includeTransformAssetsUrls = true,
   } = ctx.moduleOptions
 
@@ -36,7 +35,7 @@ export function configureNuxt(
 
   nuxt.options.css ??= []
 
-  //should always add vuetify/styles.
+  // always add vuetify/styles
   nuxt.options.css.unshift('vuetify/styles')
 
   if (includeTransformAssetsUrls && typeof nuxt.options.vite.vue?.template?.transformAssetUrls === 'undefined') {


### PR DESCRIPTION
During my troubleshooting #212, regarding using custom Sass styles in components, only by manually importing Vuetify styles the custom Sass changes are applied without causing UI disruption.

```js
  vuetify: {
    moduleOptions: {
      styles: {
        configFile: 'assets/scss/settings.scss',
      },
    },
  },
  
  css: [
    'vuetify/styles',
  ],
  ```
 
 With this tiny fix,  styles will always be imported therefore no manual syle import is necessary anymore.
 This is a suggestion from Kael.

