### PR TITLE
fix: `transformAssetUrls` stops working

### DIFF
--- a/src/utils/configure-nuxt.ts
+++ b/src/utils/configure-nuxt.ts
@@ -1,12 +1,9 @@
 import type { Nuxt } from '@nuxt/schema'
 import { addImports, addPlugin, extendWebpackConfig } from '@nuxt/kit'
-import { transformAssetUrls as vuetifyTransformAssetUrls } from 'vite-plugin-vuetify'
-import defu from 'defu'
-import type { AssetURLOptions } from '@vue/compiler-sfc'
 import { RESOLVED_VIRTUAL_MODULES } from '../vite/constants'
 import type { VuetifyNuxtContext } from './config'
 import { addVuetifyNuxtPlugins } from './vuetify-nuxt-plugins'
-import { normalizeTransformAssetUrls, toKebabCase } from './index'
+import { toKebabCase } from './index'
 
 export function configureNuxt(
   configKey: string,
@@ -16,7 +13,6 @@ export function configureNuxt(
   const {
     importComposables,
     prefixComposables,
-    includeTransformAssetsUrls = true,
   } = ctx.moduleOptions
 
   const runtimeDir = ctx.resolver.resolve('./runtime')
@@ -37,37 +33,6 @@ export function configureNuxt(
 
   // always add vuetify/styles
   nuxt.options.css.unshift('vuetify/styles')
-
-  if (includeTransformAssetsUrls) {
-    nuxt.options.vite.vue ??= {}
-    nuxt.options.vite.vue.template ??= {}
-    let existingTransformAssetUrls = nuxt.options.vite.vue?.template?.transformAssetUrls ?? {}
-    let useURLOptions: AssetURLOptions | undefined
-    if (typeof existingTransformAssetUrls === 'boolean') {
-      existingTransformAssetUrls = {}
-    }
-    else if ('base' in existingTransformAssetUrls || 'includeAbsolute' in existingTransformAssetUrls || 'tags' in existingTransformAssetUrls) {
-      useURLOptions = {
-        base: existingTransformAssetUrls.base as string | undefined,
-        includeAbsolute: existingTransformAssetUrls.includeAbsolute as boolean | undefined,
-      }
-      existingTransformAssetUrls = (existingTransformAssetUrls.tags ?? {}) as Record<string, string[]>
-    }
-
-    const transformAssetUrls = normalizeTransformAssetUrls(
-      typeof includeTransformAssetsUrls === 'object'
-        ? defu(existingTransformAssetUrls, vuetifyTransformAssetUrls, includeTransformAssetsUrls)
-        : defu(existingTransformAssetUrls, vuetifyTransformAssetUrls),
-    )
-
-    if (useURLOptions) {
-      useURLOptions.tags = transformAssetUrls
-      nuxt.options.vite.vue.template.transformAssetUrls = useURLOptions
-    }
-    else {
-      nuxt.options.vite.vue.template.transformAssetUrls = transformAssetUrls
-    }
-  }
 
   extendWebpackConfig(() => {
     throw new Error('Webpack is not supported: vuetify-nuxt-module module can only be used with Vite!')

--- a/src/utils/configure-vite.ts
+++ b/src/utils/configure-vite.ts
@@ -37,7 +37,7 @@ export function configureVite(configKey: string, nuxt: Nuxt, ctx: VuetifyNuxtCon
     if (includeTransformAssetsUrls) {
       viteInlineConfig.vue ??= {}
       viteInlineConfig.vue.template ??= {}
-      let existingTransformAssetUrls = viteInlineConfig.vue?.template?.transformAssetUrls ?? {}
+      let existingTransformAssetUrls = viteInlineConfig.vue.template.transformAssetUrls ?? {}
       let useURLOptions: AssetURLOptions | undefined
       if (typeof existingTransformAssetUrls === 'boolean') {
         existingTransformAssetUrls = {}


### PR DESCRIPTION
It seems latest nuxt (maybe can be also vue 3.4) including `vite.vue.template.transformAssetUrls`, this PR just merges existing, vuetify and user provided

https://github.com/nuxt/nuxt/blob/7c8f78d27e54f1adc1527e38b232ad9852058fe1/packages/schema/src/config/app.ts#L11-L18

closes #220