### PR TITLE
fix: don't use JSON parse to load configuration

### DIFF
--- a/src/vite/vuetify-configuration-plugin.ts
+++ b/src/vite/vuetify-configuration-plugin.ts
@@ -49,7 +49,7 @@ export function vuetifyConfigurationPlugin(ctx: VuetifyNuxtContext) {
 
 export const isDev = ${ctx.isDev}
 export function vuetifyConfiguration() {
-  const options = JSON.parse('${JSON.stringify(newVuetifyOptions)}')
+  const options = ${JSON.stringify(newVuetifyOptions)}
   ${result.directives}
   ${result.aliases}
   ${result.components}


### PR DESCRIPTION
This PR just writes the configuration without using JSON.parse, some locales using some chars breaking json. This may have some (small) performance loss.

closes #222