### PR TITLE
fix(date): allow configure `i18n` when using custom `adapter`

### DIFF
--- a/src/runtime/plugins/date.ts
+++ b/src/runtime/plugins/date.ts
@@ -3,8 +3,8 @@ import type { VuetifyOptions } from 'vuetify'
 import { useNuxtApp } from '#imports'
 
 export function configureDate(vuetifyOptions: VuetifyOptions) {
-  if (adapter === 'custom' || !enabled)
-    return
+  // if (adapter === 'custom' || !enabled)
+  //   return
 
   const dateOptions = dateConfiguration()
 


### PR DESCRIPTION
If you want to use a custom date adapter, you can configure it using vuetifyOptions.date.adapter = 'custom'

