### PR TITLE
Update README.md to install vuetify first

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@
 > Requires Vite, will not work with Webpack
 
 ```bash
+npm install vuetify
 npx nuxi@latest module add vuetify-nuxt-module
 ```
 


### PR DESCRIPTION
Without this change the `npx` command evokes this error: "Cannot find module 'vuetify/package.json'"

### Description

<!-- Please insert your description here and provide info about the "what" this PR is solving. -->

### Linked Issues

<!-- e.g. fixes #123 -->

### Additional Context

<!-- Is there anything you would like the reviewers to focus on? -->

---

> [!TIP]
> The author of this PR can publish a _preview release_ by commenting `/publish` below.
