### PR TITLE
chore(publish): move npm publish to CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,5 @@
 name: Release
 
-permissions:
-  contents: write
-
 on:
   push:
     tags:
@@ -10,16 +7,9 @@ on:
 
 jobs:
   release:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-
-      - uses: actions/setup-node@v3
-        with:
-          node-version: 18
-
-      - run: npx changelogithub
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    uses: sxzz/workflows/.github/workflows/release.yml@v1
+    with:
+      publish: true
+    permissions:
+      contents: write
+      id-token: write

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "publint": "publint",
     "test": "vitest run",
     "test:watch": "vitest watch",
-    "release": "bumpp && npm publish"
+    "release": "bumpp"
   },
   "dependencies": {
     "@nuxt/kit": "^3.12.4",


### PR DESCRIPTION
This PR also adds Trusted Publisher, I need to add GH Actions Truster Publisher entry at npm registry