### PR TITLE
fix(i18n): include decimal separator

### DIFF
--- a/src/runtime/plugins/i18n.ts
+++ b/src/runtime/plugins/i18n.ts
@@ -1,9 +1,13 @@
 import type { Ref } from 'vue'
-import { ref, watch } from 'vue'
+import { ref, watch, toRef } from 'vue'
 import type { LocaleInstance, LocaleMessages, LocaleOptions, VuetifyOptions } from 'vuetify'
 import type { Locale } from 'vue-i18n'
 import { useI18n } from 'vue-i18n'
 import { useNuxtApp } from '#imports'
+
+function inferDecimalSeparator(n: ReturnType<typeof useI18n>['n']) {
+  return n(0.1).includes(',') ? ',' : '.'
+}
 
 export function createAdapter(vuetifyOptions: VuetifyOptions) {
   vuetifyOptions.locale = {}
@@ -37,6 +41,7 @@ export function createAdapter(vuetifyOptions: VuetifyOptions) {
     t: (key, ...params) => i18n.t(key, params),
     n: i18n.n,
     provide: createProvideFunction({ current: currentLocale, fallback, messages }),
+    decimalSeparator: toRef(() => inferDecimalSeparator(i18n.n)),
   }
 }
 
@@ -75,6 +80,7 @@ function createProvideFunction(data: {
       messages: data.messages,
       t,
       n,
+      decimalSeparator: toRef(() => props.decimalSeparator ?? inferDecimalSeparator(n)),
       provide: createProvideFunction({ current: currentLocale, fallback: data.fallback, messages: data.messages }),
     }
   }


### PR DESCRIPTION
Add `decimalSeparator` to i18n adapter and Vue props

### Description

<!-- Please insert your description here and provide info about the "what" this PR is solving. -->

### Linked Issues

#324 

### Additional Context

[<!-- Is there anything you would like the reviewers to focus on? -->](https://github.com/vuetifyjs/vuetify/commit/534c1e72363dadfee213f0360272c29d308b28af#diff-93c6db6e8d5edf01b3bdc2477f65568f637d63decac01916f218d87c057230e8R115)

---

> [!TIP]
> The author of this PR can publish a _preview release_ by commenting `/publish` below.
