### PR TITLE
Fix configFile path in sass-customization guide

### DIFF
--- a/docs/guide/sass-customization.md
+++ b/docs/guide/sass-customization.md
@@ -59,7 +59,7 @@ export default defineNuxtConfig({
       /* https://www.youtube.com/watch?v=aamWg1TuC3o */
       disableVuetifyStyles: true,
       styles: {
-        configFile: '@/assets/css/components.scss'
+        configFile: '/assets/css/components.scss'
       },
     },
   }


### PR DESCRIPTION
It does not work with the prefix @ or ~ used today. If you omit the prefix, it works without errors.

### Description

<!-- Please insert your description here and provide info about the "what" this PR is solving. -->

### Linked Issues

<!-- e.g. fixes #123 -->

### Additional Context

<!-- Is there anything you would like the reviewers to focus on? -->

---

> [!TIP]
> The author of this PR can publish a _preview release_ by commenting `/publish` below.
