### PR TITLE
build: support nuxt 4 and vuetify 4 version range

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,18 +75,18 @@
     "release": "bumpp"
   },
   "dependencies": {
-    "@nuxt/kit": "3.15.4",
+    "@nuxt/kit": "^3.15.4 || ^4.0.0",
     "defu": "^6.1.4",
     "destr": "^2.0.3",
-    "local-pkg": "^0.5.0",
+    "local-pkg": "^1.1.2",
     "pathe": "^1.1.2",
     "perfect-debounce": "^1.0.0",
     "semver": "^7.7.3",
     "ufo": "^1.5.4",
-    "unconfig": "^0.5.5",
+    "unconfig": "^7.4.2",
     "upath": "^2.0.1",
-    "vite-plugin-vuetify": "^2.1.2",
-    "vuetify": "^3.7.0"
+    "vite-plugin-vuetify": "^2.1.3",
+    "vuetify": "^3.7.0 || ^4.0.0-0"
   },
   "devDependencies": {
     "@antfu/eslint-config": "^0.43.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,8 +23,8 @@ importers:
         specifier: ^2.0.3
         version: 2.0.3
       local-pkg:
-        specifier: ^0.5.0
-        version: 0.5.0
+        specifier: ^1.1.2
+        version: 1.1.2
       pathe:
         specifier: ^1.1.2
         version: 1.1.2
@@ -38,17 +38,17 @@ importers:
         specifier: ^1.5.4
         version: 1.5.4
       unconfig:
-        specifier: ^0.5.5
-        version: 0.5.5
+        specifier: ^7.4.2
+        version: 7.4.2
       upath:
         specifier: ^2.0.1
         version: 2.0.1
       vite-plugin-vuetify:
-        specifier: ^2.1.2
-        version: 2.1.2(vite@6.4.1(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2))(vue@3.4.31(typescript@5.5.4))(vuetify@3.7.0)
+        specifier: ^2.1.3
+        version: 2.1.3(vite@6.4.1(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2))(vue@3.4.31(typescript@5.5.4))(vuetify@3.7.0)
       vuetify:
-        specifier: ^3.7.0
-        version: 3.7.0(typescript@5.5.4)(vite-plugin-vuetify@2.1.2)(vue-i18n@9.10.2(vue@3.4.31(typescript@5.5.4)))(vue@3.4.31(typescript@5.5.4))
+        specifier: ^3.7.0 || ^4.0.0
+        version: 3.7.0(typescript@5.5.4)(vite-plugin-vuetify@2.1.3)(vue-i18n@9.10.2(vue@3.4.31(typescript@5.5.4)))(vue@3.4.31(typescript@5.5.4))
     devDependencies:
       '@antfu/eslint-config':
         specifier: ^0.43.1
@@ -79,16 +79,16 @@ importers:
         version: 7.4.47
       '@nuxt/devtools':
         specifier: latest
-        version: 3.1.1(vite@6.4.1(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2))(vue@3.4.31(typescript@5.5.4))
+        version: 3.1.1(vite@6.4.1(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2))(vue@3.4.31(typescript@5.5.4))
       '@nuxt/module-builder':
         specifier: ^1.0.2
-        version: 1.0.2(@nuxt/cli@3.31.2(cac@6.7.14)(magicast@0.5.1))(@vue/compiler-core@3.5.25)(esbuild@0.23.0)(sass@1.77.8)(typescript@5.5.4)(vue-tsc@2.1.10(typescript@5.5.4))(vue@3.4.31(typescript@5.5.4))
+        version: 1.0.2(@nuxt/cli@3.31.2(cac@6.7.14)(magicast@0.5.1))(@vue/compiler-core@3.5.25)(esbuild@0.25.12)(sass@1.77.8)(typescript@5.5.4)(vue-tsc@2.1.10(typescript@5.5.4))(vue@3.4.31(typescript@5.5.4))
       '@nuxt/schema':
         specifier: ^3.15.4
         version: 3.15.4
       '@nuxt/test-utils':
         specifier: ^3.13.1
-        version: 3.13.1(h3@1.15.4)(magicast@0.5.1)(nitropack@2.12.9(encoding@0.1.13))(vite@6.4.1(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2))(vitest@3.2.4(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2))(vue-router@4.6.4(vue@3.4.31(typescript@5.5.4)))(vue@3.4.31(typescript@5.5.4))
+        version: 3.13.1(h3@1.15.4)(magicast@0.5.1)(nitropack@2.12.9(encoding@0.1.13))(vite@6.4.1(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2))(vitest@3.2.4(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2))(vue-router@4.6.4(vue@3.4.31(typescript@5.5.4)))(vue@3.4.31(typescript@5.5.4))
       '@nuxtjs/i18n':
         specifier: ^8.0.0
         version: 8.3.3(magicast@0.5.1)(rollup@4.53.4)(vue@3.4.31(typescript@5.5.4))
@@ -103,7 +103,7 @@ importers:
         version: 7.7.1
       '@unocss/nuxt':
         specifier: ^66.5.10
-        version: 66.5.10(magicast@0.5.1)(postcss@8.5.6)(vite@6.4.1(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2))(webpack@5.88.2(esbuild@0.23.0))
+        version: 66.5.10(magicast@0.5.1)(postcss@8.5.6)(vite@6.4.1(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2))(webpack@5.88.2(esbuild@0.25.12))
       bumpp:
         specifier: ^9.2.0
         version: 9.2.0(magicast@0.5.1)
@@ -115,7 +115,7 @@ importers:
         version: 3.4.3
       nuxt:
         specifier: ^3.15.4
-        version: 3.15.4(@parcel/watcher@2.4.1)(@types/node@18.0.0)(cac@6.7.14)(db0@0.3.4)(encoding@0.1.13)(eslint@8.54.0)(ioredis@5.8.2)(magicast@0.5.1)(optionator@0.9.3)(rollup@4.53.4)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(typescript@5.5.4)(vite@6.4.1(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2))(vue-tsc@2.1.10(typescript@5.5.4))(yaml@2.8.2)
+        version: 3.15.4(@parcel/watcher@2.4.1)(@types/node@18.0.0)(cac@6.7.14)(db0@0.3.4)(encoding@0.1.13)(eslint@8.54.0)(ioredis@5.8.2)(magicast@0.5.1)(optionator@0.9.3)(rollup@4.53.4)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(typescript@5.5.4)(vite@6.4.1(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2))(vue-tsc@2.1.10(typescript@5.5.4))(yaml@2.8.2)
       publint:
         specifier: ^0.2.10
         version: 0.2.10
@@ -130,10 +130,10 @@ importers:
         version: 5.5.4
       vite:
         specifier: 6.4.1
-        version: 6.4.1(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2)
+        version: 6.4.1(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2)
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2)
+        version: 3.2.4(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2)
       vue-tsc:
         specifier: ^2.1.10
         version: 2.1.10(typescript@5.5.4)
@@ -184,7 +184,7 @@ importers:
         version: 0.7.9
       '@unocss/nuxt':
         specifier: ^66.5.10
-        version: 66.5.10(magicast@0.3.5)(postcss@8.5.6)(vite@6.4.1(@types/node@25.0.2)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2))(webpack@5.88.2(esbuild@0.23.0))
+        version: 66.5.10(magicast@0.3.5)(postcss@8.5.6)(vite@6.4.1(@types/node@25.0.2)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2))(webpack@5.88.2(esbuild@0.25.12))
       date-fns:
         specifier: ^2.30.0
         version: 2.30.0
@@ -208,7 +208,7 @@ importers:
         version: 0.9.2
       nuxt:
         specifier: ^3.15.4
-        version: 3.15.4(@parcel/watcher@2.5.1)(@types/node@25.0.2)(cac@6.7.14)(db0@0.3.4)(encoding@0.1.13)(eslint@8.54.0)(ioredis@5.8.2)(magicast@0.3.5)(optionator@0.9.3)(rollup@4.53.4)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(typescript@5.5.4)(vite@6.4.1(@types/node@25.0.2)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2))(vue-tsc@2.1.10(typescript@5.5.4))(yaml@2.8.2)
+        version: 3.15.4(@parcel/watcher@2.5.1)(@types/node@25.0.2)(cac@6.7.14)(db0@0.3.4)(encoding@0.1.13)(eslint@8.54.0)(ioredis@5.8.2)(magicast@0.3.5)(optionator@0.9.3)(rollup@4.53.4)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(typescript@5.5.4)(vite@6.4.1(@types/node@25.0.2)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2))(vue-tsc@2.1.10(typescript@5.5.4))(yaml@2.8.2)
       sass-embedded:
         specifier: ^1.77.8
         version: 1.77.8
@@ -242,19 +242,19 @@ importers:
         version: 0.2.4
       '@vite-pwa/vitepress':
         specifier: ^0.5.0
-        version: 0.5.0(@vite-pwa/assets-generator@0.2.4)(vite-plugin-pwa@0.20.1(@vite-pwa/assets-generator@0.2.4)(vite@6.4.1(@types/node@20.6.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2))(workbox-build@7.0.0)(workbox-window@7.1.0))
+        version: 0.5.0(@vite-pwa/assets-generator@0.2.4)(vite-plugin-pwa@0.20.1(@vite-pwa/assets-generator@0.2.4)(vite@6.4.1(@types/node@20.6.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2))(workbox-build@7.0.0)(workbox-window@7.1.0))
       sitemap:
         specifier: ^8.0.0
         version: 8.0.0
       unocss:
         specifier: ^0.62.1
-        version: 0.62.1(@unocss/webpack@0.62.1(rollup@2.79.2)(webpack@5.88.2(esbuild@0.23.0)))(postcss@8.5.6)(rollup@2.79.2)(vite@6.4.1(@types/node@20.6.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2))
+        version: 0.62.1(@unocss/webpack@0.62.1(rollup@2.79.2)(webpack@5.88.2(esbuild@0.25.12)))(postcss@8.5.6)(rollup@2.79.2)(vite@6.4.1(@types/node@20.6.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2))
       vite-plugin-pwa:
         specifier: ^0.20.1
-        version: 0.20.1(@vite-pwa/assets-generator@0.2.4)(vite@6.4.1(@types/node@20.6.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2))(workbox-build@7.0.0)(workbox-window@7.1.0)
+        version: 0.20.1(@vite-pwa/assets-generator@0.2.4)(vite@6.4.1(@types/node@20.6.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2))(workbox-build@7.0.0)(workbox-window@7.1.0)
       vitepress:
         specifier: ^1.3.2
-        version: 1.3.2(@algolia/client-search@4.19.1)(@types/node@20.6.0)(jiti@2.6.1)(postcss@8.5.6)(sass-embedded@1.77.8)(sass@1.77.8)(search-insights@2.7.0)(terser@5.44.1)(tsx@4.17.0)(typescript@5.5.4)(yaml@2.8.2)
+        version: 1.3.2(@algolia/client-search@4.19.1)(@types/node@20.6.0)(jiti@2.6.1)(postcss@8.5.6)(sass-embedded@1.77.8)(sass@1.77.8)(search-insights@2.7.0)(terser@5.46.0)(tsx@4.17.0)(typescript@5.5.4)(yaml@2.8.2)
       workbox-window:
         specifier: ^7.1.0
         version: 7.1.0
@@ -266,17 +266,17 @@ importers:
         version: 1.1.68
       vuetify:
         specifier: ^3.7.0
-        version: 3.7.0(typescript@5.5.4)(vite-plugin-vuetify@2.1.2)(vue-i18n@9.10.2(vue@3.4.31(typescript@5.5.4)))(vue@3.4.31(typescript@5.5.4))
+        version: 3.7.0(typescript@5.5.4)(vite-plugin-vuetify@2.1.3)(vue-i18n@9.10.2(vue@3.4.31(typescript@5.5.4)))(vue@3.4.31(typescript@5.5.4))
     devDependencies:
       '@nuxt/devtools':
         specifier: latest
-        version: 3.1.1(vite@6.4.1(@types/node@25.0.2)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2))(vue@3.4.31(typescript@5.5.4))
+        version: 3.1.1(vite@6.4.1(@types/node@25.0.2)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2))(vue@3.4.31(typescript@5.5.4))
       '@unocss/nuxt':
         specifier: ^66.5.10
-        version: 66.5.10(magicast@0.3.5)(postcss@8.5.6)(vite@6.4.1(@types/node@25.0.2)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2))(webpack@5.88.2(esbuild@0.23.0))
+        version: 66.5.10(magicast@0.3.5)(postcss@8.5.6)(vite@6.4.1(@types/node@25.0.2)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2))(webpack@5.88.2(esbuild@0.25.12))
       nuxt:
         specifier: ^3.15.4
-        version: 3.15.4(@parcel/watcher@2.5.1)(@types/node@25.0.2)(cac@6.7.14)(db0@0.3.4)(encoding@0.1.13)(eslint@8.54.0)(ioredis@5.8.2)(magicast@0.3.5)(optionator@0.9.3)(rollup@4.53.4)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(typescript@5.5.4)(vite@6.4.1(@types/node@25.0.2)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2))(vue-tsc@2.1.10(typescript@5.5.4))(yaml@2.8.2)
+        version: 3.15.4(@parcel/watcher@2.5.1)(@types/node@25.0.2)(cac@6.7.14)(db0@0.3.4)(encoding@0.1.13)(eslint@8.54.0)(ioredis@5.8.2)(magicast@0.3.5)(optionator@0.9.3)(rollup@4.53.4)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(typescript@5.5.4)(vite@6.4.1(@types/node@25.0.2)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2))(vue-tsc@2.1.10(typescript@5.5.4))(yaml@2.8.2)
       sass-embedded:
         specifier: ^1.77.8
         version: 1.77.8
@@ -315,20 +315,20 @@ importers:
         version: 3.4.3
       vuetify:
         specifier: ^3.7.0
-        version: 3.7.0(typescript@5.5.4)(vite-plugin-vuetify@2.1.2)(vue-i18n@9.10.2(vue@3.4.31(typescript@5.5.4)))(vue@3.4.31(typescript@5.5.4))
+        version: 3.7.0(typescript@5.5.4)(vite-plugin-vuetify@2.1.3)(vue-i18n@9.10.2(vue@3.4.31(typescript@5.5.4)))(vue@3.4.31(typescript@5.5.4))
     devDependencies:
       '@nuxt/devtools':
         specifier: latest
-        version: 3.1.1(vite@6.4.1(@types/node@25.0.2)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2))(vue@3.4.31(typescript@5.5.4))
+        version: 3.1.1(vite@6.4.1(@types/node@25.0.2)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2))(vue@3.4.31(typescript@5.5.4))
       '@nuxtjs/i18n':
         specifier: ^8.3.3
         version: 8.3.3(magicast@0.3.5)(rollup@4.53.4)(vue@3.4.31(typescript@5.5.4))
       '@unocss/nuxt':
         specifier: ^0.62.1
-        version: 0.62.4(magicast@0.3.5)(postcss@8.5.6)(rollup@4.53.4)(vite@6.4.1(@types/node@25.0.2)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2))(webpack@5.88.2(esbuild@0.23.0))
+        version: 0.62.4(magicast@0.3.5)(postcss@8.5.6)(rollup@4.53.4)(vite@6.4.1(@types/node@25.0.2)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2))(webpack@5.88.2(esbuild@0.23.0))
       nuxt:
         specifier: ^3.12.4
-        version: 3.15.4(@parcel/watcher@2.5.1)(@types/node@25.0.2)(cac@6.7.14)(db0@0.3.4)(encoding@0.1.13)(eslint@8.54.0)(ioredis@5.8.2)(magicast@0.3.5)(optionator@0.9.3)(rollup@4.53.4)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(typescript@5.5.4)(vite@6.4.1(@types/node@25.0.2)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2))(vue-tsc@2.1.10(typescript@5.5.4))(yaml@2.8.2)
+        version: 3.15.4(@parcel/watcher@2.5.1)(@types/node@25.0.2)(cac@6.7.14)(db0@0.3.4)(encoding@0.1.13)(eslint@8.54.0)(ioredis@5.8.2)(magicast@0.3.5)(optionator@0.9.3)(rollup@4.53.4)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(typescript@5.5.4)(vite@6.4.1(@types/node@25.0.2)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2))(vue-tsc@2.1.10(typescript@5.5.4))(yaml@2.8.2)
       sass-embedded:
         specifier: ^1.77.8
         version: 1.77.8
@@ -349,7 +349,7 @@ importers:
         version: 8.3.3(magicast@0.3.5)(rollup@4.53.4)(vue@3.4.31(typescript@5.5.4))
       nuxt:
         specifier: ^3.15.4
-        version: 3.15.4(@parcel/watcher@2.5.1)(@types/node@25.0.2)(cac@6.7.14)(db0@0.3.4)(encoding@0.1.13)(eslint@8.54.0)(ioredis@5.8.2)(magicast@0.3.5)(optionator@0.9.3)(rollup@4.53.4)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(typescript@5.5.4)(vite@6.4.1(@types/node@25.0.2)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2))(vue-tsc@2.1.10(typescript@5.5.4))(yaml@2.8.2)
+        version: 3.15.4(@parcel/watcher@2.5.1)(@types/node@25.0.2)(cac@6.7.14)(db0@0.3.4)(encoding@0.1.13)(eslint@8.54.0)(ioredis@5.8.2)(magicast@0.3.5)(optionator@0.9.3)(rollup@4.53.4)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(typescript@5.5.4)(vite@6.4.1(@types/node@25.0.2)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2))(vue-tsc@2.1.10(typescript@5.5.4))(yaml@2.8.2)
       sass-embedded:
         specifier: ^1.77.8
         version: 1.77.8
@@ -489,12 +489,20 @@ packages:
     resolution: {integrity: sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/code-frame@7.28.6':
+    resolution: {integrity: sha512-JYgintcMjRiCvS8mMECzaEn+m3PfoQiyqukOMCCVQtoJGYJw8j/8LBJEiqkHLkfwCcs74E3pbAUFNg7d9VNJ+Q==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/compat-data@7.25.2':
     resolution: {integrity: sha512-bYcppcpKBvX4znYaPEeFau03bp89ShqNMLs+rmdptMw+heSZh9+z84d2YG+K7cYLbWwzdjtDoW/uqZmPjulClQ==}
     engines: {node: '>=6.9.0'}
 
   '@babel/compat-data@7.28.5':
     resolution: {integrity: sha512-6uFXyCayocRbqhZOB+6XcuZbkMNimwfVGFji8CTZnCzOHVGvDqzvitu1re2AU5LROliz7eQPhB8CpAMvnx9EjA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/compat-data@7.28.6':
+    resolution: {integrity: sha512-2lfu57JtzctfIrcGMz992hyLlByuzgIk58+hhGCxjKZ3rWI82NnVLjXcaTqkI2NvlcvOskZaiZ5kjUALo3Lpxg==}
     engines: {node: '>=6.9.0'}
 
   '@babel/core@7.25.2':
@@ -505,12 +513,20 @@ packages:
     resolution: {integrity: sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/core@7.28.6':
+    resolution: {integrity: sha512-H3mcG6ZDLTlYfaSNi0iOKkigqMFvkTKlGUYlD8GW7nNOYRrevuA46iTypPyv+06V3fEmvvazfntkBU34L0azAw==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/generator@7.25.0':
     resolution: {integrity: sha512-3LEEcj3PVW8pW2R1SR1M89g/qrYk/m/mB/tLqn7dn4sbBUQyTqnlod+II2U4dqiGtUmkcnAmkMDralTFZttRiw==}
     engines: {node: '>=6.9.0'}
 
   '@babel/generator@7.28.5':
     resolution: {integrity: sha512-3EwLFhZ38J4VyIP6WNtt2kUdW9dokXA9Cr4IVIFHuCpZ3H8/YFOl5JjZHisrn1fATPBmKKqXzDFvh9fUwHz6CQ==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/generator@7.28.6':
+    resolution: {integrity: sha512-lOoVRwADj8hjf7al89tvQ2a1lf53Z+7tiXMgpZJL3maQPDxh0DgLMN62B2MKUOFcoodBHLMbDM6WAbKgNy5Suw==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-annotate-as-pure@7.24.7':
@@ -529,6 +545,10 @@ packages:
     resolution: {integrity: sha512-2+1thGUUWWjLTYTHZWK1n8Yga0ijBz1XAhUXcKy81rd5g6yh7hGqMp45v7cadSbEHc9G3OTv45SyneRN3ps4DQ==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-compilation-targets@7.28.6':
+    resolution: {integrity: sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-create-class-features-plugin@7.24.8':
     resolution: {integrity: sha512-4f6Oqnmyp2PP3olgUMmOwC3akxSm5aBYraQ6YDdKy7NcAMkDECHWG0DEnV6M2UAkERgIBhYt8S27rURPg7SxWA==}
     engines: {node: '>=6.9.0'}
@@ -537,6 +557,12 @@ packages:
 
   '@babel/helper-create-class-features-plugin@7.28.5':
     resolution: {integrity: sha512-q3WC4JfdODypvxArsJQROfupPBq9+lMwjKq7C33GhbFYJsufD0yd/ziwD+hJucLeWsnFPWZjsU2DNFqBPE7jwQ==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+
+  '@babel/helper-create-class-features-plugin@7.28.6':
+    resolution: {integrity: sha512-dTOdvsjnG3xNT9Y0AUg1wAl38y+4Rl4sf9caSQZOXdNqVn+H+HbbJ4IyyHaIqNR6SW9oJpA/RuRjsjCw2IdIow==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
@@ -580,6 +606,10 @@ packages:
     resolution: {integrity: sha512-0gSFWUPNXNopqtIPQvlD5WgXYI5GY2kP2cCvoT8kczjbfcfuIljTbcWrulD1CIPIX2gt1wghbDy08yE1p+/r3w==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-module-imports@7.28.6':
+    resolution: {integrity: sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-module-transforms@7.25.2':
     resolution: {integrity: sha512-BjyRAbix6j/wv83ftcVJmBt72QtHI56C7JXZoG2xATiLpmoC7dpd8WnkikExHDVPpi/3qCmO6WY1EaXOluiecQ==}
     engines: {node: '>=6.9.0'}
@@ -588,6 +618,12 @@ packages:
 
   '@babel/helper-module-transforms@7.28.3':
     resolution: {integrity: sha512-gytXUbs8k2sXS9PnQptz5o0QnpLL51SwASIORY6XaBKF88nsOT0Zw9szLqlSGQDP/4TljBAD5y98p2U1fqkdsw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+
+  '@babel/helper-module-transforms@7.28.6':
+    resolution: {integrity: sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
@@ -608,6 +644,10 @@ packages:
     resolution: {integrity: sha512-1gn1Up5YXka3YYAHGKpbideQ5Yjf1tDa9qYcgysz+cNCXukyLl6DjPXhD3VRwSb8c0J9tA4b2+rHEZtc6R0tlw==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-plugin-utils@7.28.6':
+    resolution: {integrity: sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-remap-async-to-generator@7.27.1':
     resolution: {integrity: sha512-7fiA521aVw8lSPeI4ZOD3vRFkoqkJcS+z4hFo82bFSH/2tNd6eJ5qCVMS5OzDmZh/kaHQeBaeyxK6wljcPtveA==}
     engines: {node: '>=6.9.0'}
@@ -622,6 +662,12 @@ packages:
 
   '@babel/helper-replace-supers@7.27.1':
     resolution: {integrity: sha512-7EHz6qDZc8RYS5ElPoShMheWvEgERonFCs7IAonWLLUTXW59DP14bCZt89/GKyreYn8g3S83m21FelHKbeDCKA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+
+  '@babel/helper-replace-supers@7.28.6':
+    resolution: {integrity: sha512-mq8e+laIk94/yFec3DxSjCRD2Z0TAjhVbEJY3UQrlwVo15Lmt7C2wAUbK4bjnTs4APkwsYLTahXRraQXhb1WCg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
@@ -666,8 +712,8 @@ packages:
     resolution: {integrity: sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-wrap-function@7.28.3':
-    resolution: {integrity: sha512-zdf983tNfLZFletc0RRXYrHrucBEg95NIFMkn6K9dbeMYnsgHaSBGcQqdsCSStG2PYwRre0Qc2NNSCXbG+xc6g==}
+  '@babel/helper-wrap-function@7.28.6':
+    resolution: {integrity: sha512-z+PwLziMNBeSQJonizz2AGnndLsP2DeGHIxDAn+wdHOGuo4Fo1x1HBPPXeE9TAOPHNNWQKCSlA2VZyYyyibDnQ==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helpers@7.25.0':
@@ -676,6 +722,10 @@ packages:
 
   '@babel/helpers@7.28.4':
     resolution: {integrity: sha512-HFN59MmQXGHVyYadKLVumYsA9dBFun/ldYxipEjzA4196jpLZd8UjEEBLkbEkvfYreDqJhZxYAWFPtrfhNpj4w==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helpers@7.28.6':
+    resolution: {integrity: sha512-xOBvwq86HHdB7WUDTfKfT/Vuxh7gElQ+Sfti2Cy6yIWNW05P8iUslOVcZ4/sKbE+/jQaukQAdz/gf3724kYdqw==}
     engines: {node: '>=6.9.0'}
 
   '@babel/highlight@7.24.7':
@@ -694,6 +744,11 @@ packages:
 
   '@babel/parser@7.28.5':
     resolution: {integrity: sha512-KKBU1VGYR7ORr3At5HAtUQ+TV3SzRCXmA/8OdDZiLDBIZxVyzXuztPjfLd3BV1PRAQGCMWWSHYhL0F8d5uHBDQ==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/parser@7.28.6':
+    resolution: {integrity: sha512-TeR9zWR18BvbfPmGbLampPMW+uW1NZnJlRuuHso8i87QZNq2JRF9i6RgxRqtEq+wQGsS19NNTWr2duhnE49mfQ==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -721,8 +776,8 @@ packages:
     peerDependencies:
       '@babel/core': ^7.13.0
 
-  '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly@7.28.3':
-    resolution: {integrity: sha512-b6YTX108evsvE4YgWyQ921ZAFFQm3Bn+CA3+ZXlNVnPhx+UfsVURoPjfGAPCjBgrqo30yX/C2nZGX96DxvR9Iw==}
+  '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly@7.28.6':
+    resolution: {integrity: sha512-a0aBScVTlNaiUe35UtfxAN7A/tehvvG4/ByO6+46VPKTRSlfnAFsgKy0FUh+qAkQrDTmhDkT+IBOKlOoMUxQ0g==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
@@ -745,14 +800,20 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-syntax-import-assertions@7.27.1':
-    resolution: {integrity: sha512-UT/Jrhw57xg4ILHLFnzFpPDlMbcdEicaAtjPQpbj9wa8T4r5KVWCimHcL/460g8Ht0DMxDyjsLgiWSkVjnwPFg==}
+  '@babel/plugin-syntax-import-assertions@7.28.6':
+    resolution: {integrity: sha512-pSJUpFHdx9z5nqTSirOCMtYVP2wFgoWhP0p3g8ONK/4IHhLIBd0B9NYqAvIUAhq+OkhO4VM1tENCt0cjlsNShw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
   '@babel/plugin-syntax-import-attributes@7.27.1':
     resolution: {integrity: sha512-oFT0FrKHgF53f4vOsZGi2Hh3I35PfSmVs4IBFLFj4dnafP+hIWDLg3VyKmUHfLoLHlyxY4C7DGtmHuJgn+IGww==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-syntax-import-attributes@7.28.6':
+    resolution: {integrity: sha512-jiLC0ma9XkQT3TKJ9uYvlakm66Pamywo+qwL+oL8HJOvc6TWdZXVfhqJr8CCzbSGUAbDOzlGHJC1U+vRfLQDvw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -798,14 +859,14 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-transform-async-generator-functions@7.28.0':
-    resolution: {integrity: sha512-BEOdvX4+M765icNPZeidyADIvQ1m1gmunXufXxvRESy/jNNyfovIqUyE7MVgGBjWktCoJlzvFA1To2O4ymIO3Q==}
+  '@babel/plugin-transform-async-generator-functions@7.28.6':
+    resolution: {integrity: sha512-9knsChgsMzBV5Yh3kkhrZNxH3oCYAfMBkNNaVN4cP2RVlFPe8wYdwwcnOsAbkdDoV9UjFtOXWrWB52M8W4jNeA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-transform-async-to-generator@7.27.1':
-    resolution: {integrity: sha512-NREkZsZVJS4xmTr8qzE5y8AfIPqsdQfRuUiLRTEzb7Qii8iFWCyDKaUV2c0rCuh4ljDZ98ALHP/PetiBV2nddA==}
+  '@babel/plugin-transform-async-to-generator@7.28.6':
+    resolution: {integrity: sha512-ilTRcmbuXjsMmcZ3HASTe4caH5Tpo93PkTxF9oG2VZsSWsahydmcEHhix9Ik122RcTnZnUzPbmux4wh1swfv7g==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -816,32 +877,32 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-transform-block-scoping@7.28.5':
-    resolution: {integrity: sha512-45DmULpySVvmq9Pj3X9B+62Xe+DJGov27QravQJU1LLcapR6/10i+gYVAucGGJpHBp5mYxIMK4nDAT/QDLr47g==}
+  '@babel/plugin-transform-block-scoping@7.28.6':
+    resolution: {integrity: sha512-tt/7wOtBmwHPNMPu7ax4pdPz6shjFrmHDghvNC+FG9Qvj7D6mJcoRQIF5dy4njmxR941l6rgtvfSB2zX3VlUIw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-transform-class-properties@7.27.1':
-    resolution: {integrity: sha512-D0VcalChDMtuRvJIu3U/fwWjf8ZMykz5iZsg77Nuj821vCKI3zCyRLwRdWbsuJ/uRwZhZ002QtCqIkwC/ZkvbA==}
+  '@babel/plugin-transform-class-properties@7.28.6':
+    resolution: {integrity: sha512-dY2wS3I2G7D697VHndN91TJr8/AAfXQNt5ynCTI/MpxMsSzHp+52uNivYT5wCPax3whc47DR8Ba7cmlQMg24bw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-transform-class-static-block@7.28.3':
-    resolution: {integrity: sha512-LtPXlBbRoc4Njl/oh1CeD/3jC+atytbnf/UqLoqTDcEYGUPj022+rvfkbDYieUrSj3CaV4yHDByPE+T2HwfsJg==}
+  '@babel/plugin-transform-class-static-block@7.28.6':
+    resolution: {integrity: sha512-rfQ++ghVwTWTqQ7w8qyDxL1XGihjBss4CmTgGRCTAC9RIbhVpyp4fOeZtta0Lbf+dTNIVJer6ych2ibHwkZqsQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.12.0
 
-  '@babel/plugin-transform-classes@7.28.4':
-    resolution: {integrity: sha512-cFOlhIYPBv/iBoc+KS3M6et2XPtbT2HiCRfBXWtfpc9OAyostldxIf9YAYB6ypURBBbx+Qv6nyrLzASfJe+hBA==}
+  '@babel/plugin-transform-classes@7.28.6':
+    resolution: {integrity: sha512-EF5KONAqC5zAqT783iMGuM2ZtmEBy+mJMOKl2BCvPZ2lVrwvXnB6o+OBWCS+CoeCCpVRF2sA2RBKUxvT8tQT5Q==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-transform-computed-properties@7.27.1':
-    resolution: {integrity: sha512-lj9PGWvMTVksbWiDT2tW68zGS/cyo4AkZ/QTp0sQT0mjPopCmrSkzxeXkznjqBxzDI6TclZhOJbBmbBLjuOZUw==}
+  '@babel/plugin-transform-computed-properties@7.28.6':
+    resolution: {integrity: sha512-bcc3k0ijhHbc2lEfpFHgx7eYw9KNXqOerKWfzbxEHUGKnS3sz9C4CNL9OiFN1297bDNfUiSO7DaLzbvHQQQ1BQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -852,8 +913,8 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-transform-dotall-regex@7.27.1':
-    resolution: {integrity: sha512-gEbkDVGRvjj7+T1ivxrfgygpT7GUd4vmODtYpbs0gZATdkX8/iSnOtZSxiZnsgm1YjTgjI6VKBGSJJevkrclzw==}
+  '@babel/plugin-transform-dotall-regex@7.28.6':
+    resolution: {integrity: sha512-SljjowuNKB7q5Oayv4FoPzeB74g3QgLt8IVJw9ADvWy3QnUb/01aw8I4AVv8wYnPvQz2GDDZ/g3GhcNyDBI4Bg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -864,8 +925,8 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-transform-duplicate-named-capturing-groups-regex@7.27.1':
-    resolution: {integrity: sha512-hkGcueTEzuhB30B3eJCbCYeCaaEQOmQR0AdvzpD4LoN0GXMWzzGSuRrxR2xTnCrvNbVwK9N6/jQ92GSLfiZWoQ==}
+  '@babel/plugin-transform-duplicate-named-capturing-groups-regex@7.28.6':
+    resolution: {integrity: sha512-5suVoXjC14lUN6ZL9OLKIHCNVWCrqGqlmEp/ixdXjvgnEl/kauLvvMO/Xw9NyMc95Joj1AeLVPVMvibBgSoFlA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
@@ -876,14 +937,14 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-transform-explicit-resource-management@7.28.0':
-    resolution: {integrity: sha512-K8nhUcn3f6iB+P3gwCv/no7OdzOZQcKchW6N389V6PD8NUWKZHzndOd9sPDVbMoBsbmjMqlB4L9fm+fEFNVlwQ==}
+  '@babel/plugin-transform-explicit-resource-management@7.28.6':
+    resolution: {integrity: sha512-Iao5Konzx2b6g7EPqTy40UZbcdXE126tTxVFr/nAIj+WItNxjKSYTEw3RC+A2/ZetmdJsgueL1KhaMCQHkLPIg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-transform-exponentiation-operator@7.28.5':
-    resolution: {integrity: sha512-D4WIMaFtwa2NizOp+dnoFjRez/ClKiC2BqqImwKd1X28nqBtZEyCYJ2ozQrrzlxAFrcrjxo39S6khe9RNDlGzw==}
+  '@babel/plugin-transform-exponentiation-operator@7.28.6':
+    resolution: {integrity: sha512-WitabqiGjV/vJ0aPOLSFfNY1u9U3R7W36B03r5I2KoNix+a3sOhJ3pKFB3R5It9/UiK78NiO0KE9P21cMhlPkw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -906,8 +967,8 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-transform-json-strings@7.27.1':
-    resolution: {integrity: sha512-6WVLVJiTjqcQauBhn1LkICsR2H+zm62I3h9faTDKt1qP4jn2o72tSvqMwtGFKGTpojce0gJs+76eZ2uCHRZh0Q==}
+  '@babel/plugin-transform-json-strings@7.28.6':
+    resolution: {integrity: sha512-Nr+hEN+0geQkzhbdgQVPoqr47lZbm+5fCUmO70722xJZd0Mvb59+33QLImGj6F+DkK3xgDi1YVysP8whD6FQAw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -918,8 +979,8 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-transform-logical-assignment-operators@7.28.5':
-    resolution: {integrity: sha512-axUuqnUTBuXyHGcJEVVh9pORaN6wC5bYfE7FGzPiaWa3syib9m7g+/IT/4VgCOe2Upef43PHzeAvcrVek6QuuA==}
+  '@babel/plugin-transform-logical-assignment-operators@7.28.6':
+    resolution: {integrity: sha512-+anKKair6gpi8VsM/95kmomGNMD0eLz1NQ8+Pfw5sAwWH9fGYXT50E55ZpV0pHUHWf6IUTWPM+f/7AAff+wr9A==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -942,8 +1003,8 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-transform-modules-commonjs@7.27.1':
-    resolution: {integrity: sha512-OJguuwlTYlN0gBZFRPqwOGNWssZjfIUdS7HMYtN8c1KmwpwHFBwTeFZrg9XZa+DFTitWOW5iTAG7tyCUPsCCyw==}
+  '@babel/plugin-transform-modules-commonjs@7.28.6':
+    resolution: {integrity: sha512-jppVbf8IV9iWWwWTQIxJMAJCWBuuKx71475wHwYytrRGQ2CWiDvYlADQno3tcYpS/T2UUWFQp3nVtYfK/YBQrA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -972,20 +1033,20 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-transform-nullish-coalescing-operator@7.27.1':
-    resolution: {integrity: sha512-aGZh6xMo6q9vq1JGcw58lZ1Z0+i0xB2x0XaauNIUXd6O1xXc3RwoWEBlsTQrY4KQ9Jf0s5rgD6SiNkaUdJegTA==}
+  '@babel/plugin-transform-nullish-coalescing-operator@7.28.6':
+    resolution: {integrity: sha512-3wKbRgmzYbw24mDJXT7N+ADXw8BC/imU9yo9c9X9NKaLF1fW+e5H1U5QjMUBe4Qo4Ox/o++IyUkl1sVCLgevKg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-transform-numeric-separator@7.27.1':
-    resolution: {integrity: sha512-fdPKAcujuvEChxDBJ5c+0BTaS6revLV7CJL08e4m3de8qJfNIuCc2nc7XJYOjBoTMJeqSmwXJ0ypE14RCjLwaw==}
+  '@babel/plugin-transform-numeric-separator@7.28.6':
+    resolution: {integrity: sha512-SJR8hPynj8outz+SlStQSwvziMN4+Bq99it4tMIf5/Caq+3iOc0JtKyse8puvyXkk3eFRIA5ID/XfunGgO5i6w==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-transform-object-rest-spread@7.28.4':
-    resolution: {integrity: sha512-373KA2HQzKhQCYiRVIRr+3MjpCObqzDlyrM6u4I201wL8Mp2wHf7uB8GhDwis03k2ti8Zr65Zyyqs1xOxUF/Ew==}
+  '@babel/plugin-transform-object-rest-spread@7.28.6':
+    resolution: {integrity: sha512-5rh+JR4JBC4pGkXLAcYdLHZjXudVxWMXbB6u6+E9lRL5TrGVbHt1TjxGbZ8CkmYw9zjkB7jutzOROArsqtncEA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -996,14 +1057,14 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-transform-optional-catch-binding@7.27.1':
-    resolution: {integrity: sha512-txEAEKzYrHEX4xSZN4kJ+OfKXFVSWKB2ZxM9dpcE3wT7smwkNmXo5ORRlVzMVdJbD+Q8ILTgSD7959uj+3Dm3Q==}
+  '@babel/plugin-transform-optional-catch-binding@7.28.6':
+    resolution: {integrity: sha512-R8ja/Pyrv0OGAvAXQhSTmWyPJPml+0TMqXlO5w+AsMEiwb2fg3WkOvob7UxFSL3OIttFSGSRFKQsOhJ/X6HQdQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-transform-optional-chaining@7.28.5':
-    resolution: {integrity: sha512-N6fut9IZlPnjPwgiQkXNhb+cT8wQKFlJNqcZkWlcTqkcqx6/kU4ynGmLFoa4LViBSirn05YAwk+sQBbPfxtYzQ==}
+  '@babel/plugin-transform-optional-chaining@7.28.6':
+    resolution: {integrity: sha512-A4zobikRGJTsX9uqVFdafzGkqD30t26ck2LmOzAuLL8b2x6k3TIqRiT2xVvA9fNmFeTX484VpsdgmKNA0bS23w==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -1014,14 +1075,14 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-transform-private-methods@7.27.1':
-    resolution: {integrity: sha512-10FVt+X55AjRAYI9BrdISN9/AQWHqldOeZDUoLyif1Kn05a56xVBXb8ZouL8pZ9jem8QpXaOt8TS7RHUIS+GPA==}
+  '@babel/plugin-transform-private-methods@7.28.6':
+    resolution: {integrity: sha512-piiuapX9CRv7+0st8lmuUlRSmX6mBcVeNQ1b4AYzJxfCMuBfB0vBXDiGSmm03pKJw1v6cZ8KSeM+oUnM6yAExg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-transform-private-property-in-object@7.27.1':
-    resolution: {integrity: sha512-5J+IhqTi1XPa0DXF83jYOaARrX+41gOewWbkPyjMNRDqgOCqdffGh8L3f/Ek5utaEBZExjSAzcyjmV9SSAWObQ==}
+  '@babel/plugin-transform-private-property-in-object@7.28.6':
+    resolution: {integrity: sha512-b97jvNSOb5+ehyQmBpmhOCiUC5oVK4PMnpRvO7+ymFBoqYjeDHIU9jnrNUuwHOiL9RpGDoKBpSViarV+BU+eVA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -1032,14 +1093,14 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-transform-regenerator@7.28.4':
-    resolution: {integrity: sha512-+ZEdQlBoRg9m2NnzvEeLgtvBMO4tkFBw5SQIUgLICgTrumLoU7lr+Oghi6km2PFj+dbUt2u1oby2w3BDO9YQnA==}
+  '@babel/plugin-transform-regenerator@7.28.6':
+    resolution: {integrity: sha512-eZhoEZHYQLL5uc1gS5e9/oTknS0sSSAtd5TkKMUp3J+S/CaUjagc0kOUPsEbDmMeva0nC3WWl4SxVY6+OBuxfw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-transform-regexp-modifiers@7.27.1':
-    resolution: {integrity: sha512-TtEciroaiODtXvLZv4rmfMhkCv8jx3wgKpL68PuiPh2M4fvz5jhsA7697N1gMvkvr/JTF13DrFYyEbY9U7cVPA==}
+  '@babel/plugin-transform-regexp-modifiers@7.28.6':
+    resolution: {integrity: sha512-QGWAepm9qxpaIs7UM9FvUSnCGlb8Ua1RhyM4/veAxLwt3gMat/LSGrZixyuj4I6+Kn9iwvqCyPTtbdxanYoWYg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
@@ -1056,8 +1117,8 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-transform-spread@7.27.1':
-    resolution: {integrity: sha512-kpb3HUqaILBJcRFVhFUs6Trdd4mkrzcGXss+6/mxUd273PfbWqSDHRzMT2234gIg2QYfAjvXLSquP1xECSg09Q==}
+  '@babel/plugin-transform-spread@7.28.6':
+    resolution: {integrity: sha512-9U4QObUC0FtJl05AsUcodau/RWDytrU6uKgkxu09mLR9HLDAtUMoPuuskm5huQsoktmsYpI+bGmq+iapDcriKA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -1098,8 +1159,8 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-transform-unicode-property-regex@7.27.1':
-    resolution: {integrity: sha512-uW20S39PnaTImxp39O5qFlHLS9LJEmANjMG7SxIhap8rCHqu0Ik+tLEPX5DKmHn6CsWQ7j3lix2tFOa5YtL12Q==}
+  '@babel/plugin-transform-unicode-property-regex@7.28.6':
+    resolution: {integrity: sha512-4Wlbdl/sIZjzi/8St0evF0gEZrgOswVO6aOzqxh1kDZOl9WmLrHq2HtGhnOJZmHZYKP8WZ1MDLCt5DAWwRo57A==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -1110,14 +1171,14 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-transform-unicode-sets-regex@7.27.1':
-    resolution: {integrity: sha512-EtkOujbc4cgvb0mlpQefi4NTPBzhSIevblFevACNLUspmrALgmEBdL/XfnyyITfd8fKBZrZys92zOWcik7j9Tw==}
+  '@babel/plugin-transform-unicode-sets-regex@7.28.6':
+    resolution: {integrity: sha512-/wHc/paTUmsDYN7SZkpWxogTOBNnlx7nBQYfy6JJlCT7G3mVhltk3e++N7zV0XfgGsrqBxd4rJQt9H16I21Y1Q==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
 
-  '@babel/preset-env@7.28.5':
-    resolution: {integrity: sha512-S36mOoi1Sb6Fz98fBfE+UZSpYw5mJm0NUHtIKrOuNcqeFauy1J6dIvXm2KRVKobOSaGq4t/hBXdN4HGU3wL9Wg==}
+  '@babel/preset-env@7.28.6':
+    resolution: {integrity: sha512-GaTI4nXDrs7l0qaJ6Rg06dtOXTBCG6TMDB44zbqofCIC4PqC7SEvmFFtpxzCDw9W5aJ7RKVshgXTLvLdBFV/qw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -1137,8 +1198,8 @@ packages:
     resolution: {integrity: sha512-wDb5pWm4WDdF6LFUde3Jl8WzPA+3ZbxYqkC6xAXuD3irdEHN1k0NfTRrJD8ZD378SJ61miMLCqIOXYhd8x+AJQ==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/runtime@7.28.4':
-    resolution: {integrity: sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==}
+  '@babel/runtime@7.28.6':
+    resolution: {integrity: sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==}
     engines: {node: '>=6.9.0'}
 
   '@babel/standalone@7.28.5':
@@ -1153,6 +1214,10 @@ packages:
     resolution: {integrity: sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/template@7.28.6':
+    resolution: {integrity: sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/traverse@7.25.3':
     resolution: {integrity: sha512-HefgyP1x754oGCsKmV5reSmtV7IXj/kpaE1XYY+D9G5PvKKoFfSbiS4M77MdjuwlZKDIKFCffq9rPU+H/s3ZdQ==}
     engines: {node: '>=6.9.0'}
@@ -1165,12 +1230,20 @@ packages:
     resolution: {integrity: sha512-TCCj4t55U90khlYkVV/0TfkJkAkUg3jZFA3Neb7unZT8CPok7iiRfaX0F+WnqWqt7OxhOn0uBKXCw4lbL8W0aQ==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/traverse@7.28.6':
+    resolution: {integrity: sha512-fgWX62k02qtjqdSNTAGxmKYY/7FSL9WAS1o2Hu5+I5m9T0yxZzr4cnrfXQ/MX0rIifthCSs6FKTlzYbJcPtMNg==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/types@7.25.2':
     resolution: {integrity: sha512-YTnYtra7W9e6/oAZEHj0bJehPRUlLH9/fbpT5LfB0NhQXyALCRkRs3zH9v07IYhkgpqX6Z78FnuccZr/l4Fs4Q==}
     engines: {node: '>=6.9.0'}
 
   '@babel/types@7.28.5':
     resolution: {integrity: sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/types@7.28.6':
+    resolution: {integrity: sha512-0ZrskXVEHSWIqZM/sQZ4EV3jZJXRkio/WCxaqKZP1g//CEWEPSfeZFcms4XeKBCHU0ZKnIkdJeU/kF+eRp5lBg==}
     engines: {node: '>=6.9.0'}
 
   '@bomb.sh/tab@0.0.9':
@@ -2602,11 +2675,14 @@ packages:
   '@types/node@18.0.0':
     resolution: {integrity: sha512-cHlGmko4gWLVI27cGJntjs/Sj8th9aYwplmZFwmmgYQQvL5NUsgVJG7OddLvNfLqYS31KFN0s3qlaD9qCaxACA==}
 
+  '@types/node@18.19.130':
+    resolution: {integrity: sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==}
+
   '@types/node@20.17.4':
     resolution: {integrity: sha512-Fi1Bj8qTJr4f1FDdHFR7oMlOawEYSzkHNdBJK+aRjcDDNHwEV3jPPjuZP2Lh2QNgXeqzM8Y+U6b6urKAog2rZw==}
 
-  '@types/node@20.19.27':
-    resolution: {integrity: sha512-N2clP5pJhB2YnZJ3PIHFk5RkygRX5WO/5f0WC08tp0wd+sv0rsJk3MqWn3CbNmT2J505a5336jaQj4ph1AdMug==}
+  '@types/node@20.19.30':
+    resolution: {integrity: sha512-WJtwWJu7UdlvzEAUm484QNg5eAoq5QR08KDNx7g45Usrs2NtOPiX8ugDqmKdXkyL03rBqU5dYNYVQetEpBHq2g==}
 
   '@types/node@20.6.0':
     resolution: {integrity: sha512-najjVq5KN2vsH2U/xyh2opaSEz6cZMR2SetLIlxlj08nOcmPOemJmUK2o4kUzfLqfrWE0PIrNeE16XhYDd3nqg==}
@@ -3221,11 +3297,11 @@ packages:
   '@vue/shared@3.5.25':
     resolution: {integrity: sha512-AbOPdQQnAnzs58H2FrrDxYj/TJfmeS2jdfEEhgiKINy+bnOANmVizIEgq1r+C5zsbs6l1CCQxtcj71rwNQ4jWg==}
 
-  '@vuetify/loader-shared@2.1.1':
-    resolution: {integrity: sha512-jSZTzTYaoiv8iwonFCVZQ0YYX/M+Uyl4ng+C4egMJT0Hcmh9gIxJL89qfZICDeo3g0IhqrvipW2FFKKRDMtVcA==}
+  '@vuetify/loader-shared@2.1.2':
+    resolution: {integrity: sha512-X+1jBLmXHkpQEnC0vyOb4rtX2QSkBiFhaFXz8yhQqN2A4vQ6k2nChxN4Ol7VAY5KoqMdFoRMnmNdp/1qYXDQig==}
     peerDependencies:
       vue: 3.4.31
-      vuetify: ^3.0.0
+      vuetify: '>=3'
 
   '@vueuse/core@10.11.1':
     resolution: {integrity: sha512-guoy26JQktXPcz+0n3GukWIy/JDNKti9v6VEMu6kV2sYBsWuGiTU8OWdg+ADfUbHg3/3DlqySDe7JmdHrktiww==}
@@ -4345,6 +4421,7 @@ packages:
   eslint-plugin-i@2.28.1:
     resolution: {integrity: sha512-a4oVt0j3ixNhGhvV4XF6NS7OWRFK2rrJ0Q5C4S2dSRb8FxZi31J0uUd5WJLL58wnVJ/OiQ1BxiXnFA4dWQO1Cg==}
     engines: {node: '>=12'}
+    deprecated: Please migrate to the brand new `eslint-plugin-import-x` instead
     peerDependencies:
       eslint: ^7.2.0 || ^8
 
@@ -5242,10 +5319,6 @@ packages:
     resolution: {integrity: sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==}
     engines: {node: '>= 10.13.0'}
 
-  jiti@1.21.6:
-    resolution: {integrity: sha512-2yTgeWTWzMWkHu6Jp9NKgePDaYHbntiwvYuuJLbbN9vl7DC9DvXKOB2BC3ZZ92D3cvV/aflH0osDfwpHepQ53w==}
-    hasBin: true
-
   jiti@1.21.7:
     resolution: {integrity: sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==}
     hasBin: true
@@ -5379,10 +5452,6 @@ packages:
 
   local-pkg@0.4.3:
     resolution: {integrity: sha512-SFppqq5p42fe2qcZQqqEOiVRXl+WCP1MdT6k7BDEW1j++sp5fIY+/fdRQitvKgB5BrBcmrs5m/L0v2FrU5MY1g==}
-    engines: {node: '>=14'}
-
-  local-pkg@0.5.0:
-    resolution: {integrity: sha512-ok6z3qlYyCDS4ZEU27HaU6x/xZa9Whf8jD4ptH5UZTQYZVYeb9bnZ3ojVhiJNLiXK1Hfc0GNbLXcmZ5plLDDBg==}
     engines: {node: '>=14'}
 
   local-pkg@0.5.1:
@@ -7012,14 +7081,17 @@ packages:
   tar@6.2.0:
     resolution: {integrity: sha512-/Wo7DcT0u5HUV486xg675HtjNd3BXZ6xDbzsCUZPt5iw8bTQ63bP0Raut3mvro9u+CUyq7YQd8Cx55fsZXxqLQ==}
     engines: {node: '>=10'}
+    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exhorbitant rates) by contacting i@izs.me
 
   tar@6.2.1:
     resolution: {integrity: sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==}
     engines: {node: '>=10'}
+    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exhorbitant rates) by contacting i@izs.me
 
   tar@7.5.2:
     resolution: {integrity: sha512-7NyxrTE4Anh8km8iEy7o0QYPs+0JKBTj5ZaqHg6B39erLg0qYXN3BijtShwbsNSvQ+LN75+KV+C4QR/f6Gwnpg==}
     engines: {node: '>=18'}
+    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exhorbitant rates) by contacting i@izs.me
 
   temp-dir@2.0.0:
     resolution: {integrity: sha512-aoBAniQmmwtcKp/7BzsH8Cxzv8OL736p7v1ihGb5e9DJ9kTwGWHrQrVB5+lfVDzfGrdRzXch+ig7LHaY1JTOrg==}
@@ -7047,6 +7119,11 @@ packages:
 
   terser@5.44.1:
     resolution: {integrity: sha512-t/R3R/n0MSwnnazuPpPNVO60LX0SKL45pyl9YlvxIdkH0Of7D5qM2EVe+yASRIlY5pZ73nclYJfNANGWPwFDZw==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  terser@5.46.0:
+    resolution: {integrity: sha512-jTwoImyr/QbOWFFso3YoU3ik0jBBDJ6JTOQiy/J2YxVJdZCc+5u7skhNwiOR3FQIygFqVUPHl7qbbxtjW2K3Qg==}
     engines: {node: '>=10'}
     hasBin: true
 
@@ -7263,6 +7340,9 @@ packages:
 
   unctx@2.4.1:
     resolution: {integrity: sha512-AbaYw0Nm4mK4qjhns67C+kgxR2YWiwlDBPzxrN8h8C6VtAdCgditAY5Dezu3IJy4XVqAnbrXt9oQJvsn3fyozg==}
+
+  undici-types@5.26.5:
+    resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
 
   undici-types@6.19.8:
     resolution: {integrity: sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==}
@@ -7601,13 +7681,13 @@ packages:
       vite: 6.4.1
       vue: 3.4.31
 
-  vite-plugin-vuetify@2.1.2:
-    resolution: {integrity: sha512-I/wd6QS+DO6lHmuGoi1UTyvvBTQ2KDzQZ9oowJQEJ6OcjWfJnscYXx2ptm6S7fJSASuZT8jGRBL3LV4oS3LpaA==}
+  vite-plugin-vuetify@2.1.3:
+    resolution: {integrity: sha512-Q4SC/4TqbNvaZIFb9YsfBqkGlYHbJJJ6uU3CnRBZqLUF3s5eCMVZAaV4GkTbehIH/bhSj42lMXztOwc71u6rVw==}
     engines: {node: ^18.0.0 || >=20.0.0}
     peerDependencies:
       vite: 6.4.1
       vue: 3.4.31
-      vuetify: ^3.0.0
+      vuetify: '>=3'
 
   vite@6.4.1:
     resolution: {integrity: sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==}
@@ -7745,6 +7825,7 @@ packages:
   vue-i18n@9.10.2:
     resolution: {integrity: sha512-ECJ8RIFd+3c1d3m1pctQ6ywG5Yj8Efy1oYoAKQ9neRdkLbuKLVeW4gaY5HPkD/9ssf1pOnUrmIFjx2/gkGxmEw==}
     engines: {node: '>= 16'}
+    deprecated: v9 and v10 no longer supported. please migrate to v11. about maintenance status, see https://vue-i18n.intlify.dev/guide/maintenance.html
     peerDependencies:
       vue: 3.4.31
 
@@ -7799,8 +7880,8 @@ packages:
       webpack-plugin-vuetify:
         optional: true
 
-  watchpack@2.4.4:
-    resolution: {integrity: sha512-c5EGNOiyxxV5qmTtAB7rbiXxi1ooX1pQKMLX/MIabJjRA0SJBQOjKF+KSVfHkr9U1cADPon0mRiVe/riyaiDUA==}
+  watchpack@2.5.1:
+    resolution: {integrity: sha512-Zn5uXdcFNIA1+1Ei5McRd+iRzfhENPCe7LeABkJtNulSxjma+l7ltNx55BWZkRlwRnpOgHqxnjyaDgJnNXnqzg==}
     engines: {node: '>=10.13.0'}
 
   webidl-conversions@3.0.1:
@@ -7848,8 +7929,8 @@ packages:
     resolution: {integrity: sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==}
     engines: {node: '>= 0.4'}
 
-  which-typed-array@1.1.19:
-    resolution: {integrity: sha512-rEvr90Bck4WZt9HHFC4DJMsjvu7x+r6bImz0/BrbWb7A2djJ8hnZMrWnHo9F8ssv0OMErasDhftrfROTyqSDrw==}
+  which-typed-array@1.1.20:
+    resolution: {integrity: sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==}
     engines: {node: '>= 0.4'}
 
   which@2.0.2:
@@ -8227,9 +8308,17 @@ snapshots:
       js-tokens: 4.0.0
       picocolors: 1.1.1
 
+  '@babel/code-frame@7.28.6':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.28.5
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
+
   '@babel/compat-data@7.25.2': {}
 
   '@babel/compat-data@7.28.5': {}
+
+  '@babel/compat-data@7.28.6': {}
 
   '@babel/core@7.25.2':
     dependencies:
@@ -8271,6 +8360,26 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/core@7.28.6':
+    dependencies:
+      '@babel/code-frame': 7.28.6
+      '@babel/generator': 7.28.6
+      '@babel/helper-compilation-targets': 7.28.6
+      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.28.6)
+      '@babel/helpers': 7.28.6
+      '@babel/parser': 7.28.6
+      '@babel/template': 7.28.6
+      '@babel/traverse': 7.28.6
+      '@babel/types': 7.28.6
+      '@jridgewell/remapping': 2.3.5
+      convert-source-map: 2.0.0
+      debug: 4.4.3
+      gensync: 1.0.0-beta.2
+      json5: 2.2.3
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/generator@7.25.0':
     dependencies:
       '@babel/types': 7.25.2
@@ -8282,6 +8391,14 @@ snapshots:
     dependencies:
       '@babel/parser': 7.28.5
       '@babel/types': 7.28.5
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+      jsesc: 3.1.0
+
+  '@babel/generator@7.28.6':
+    dependencies:
+      '@babel/parser': 7.28.6
+      '@babel/types': 7.28.6
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
       jsesc: 3.1.0
@@ -8305,6 +8422,14 @@ snapshots:
   '@babel/helper-compilation-targets@7.27.2':
     dependencies:
       '@babel/compat-data': 7.28.5
+      '@babel/helper-validator-option': 7.27.1
+      browserslist: 4.28.1
+      lru-cache: 5.1.1
+      semver: 6.3.1
+
+  '@babel/helper-compilation-targets@7.28.6':
+    dependencies:
+      '@babel/compat-data': 7.28.6
       '@babel/helper-validator-option': 7.27.1
       browserslist: 4.28.1
       lru-cache: 5.1.1
@@ -8338,18 +8463,31 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-create-regexp-features-plugin@7.28.5(@babel/core@7.28.5)':
+  '@babel/helper-create-class-features-plugin@7.28.6(@babel/core@7.28.6)':
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.28.6
+      '@babel/helper-annotate-as-pure': 7.27.3
+      '@babel/helper-member-expression-to-functions': 7.28.5
+      '@babel/helper-optimise-call-expression': 7.27.1
+      '@babel/helper-replace-supers': 7.28.6(@babel/core@7.28.6)
+      '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
+      '@babel/traverse': 7.28.6
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-create-regexp-features-plugin@7.28.5(@babel/core@7.28.6)':
+    dependencies:
+      '@babel/core': 7.28.6
       '@babel/helper-annotate-as-pure': 7.27.3
       regexpu-core: 6.4.0
       semver: 6.3.1
 
-  '@babel/helper-define-polyfill-provider@0.6.5(@babel/core@7.28.5)':
+  '@babel/helper-define-polyfill-provider@0.6.5(@babel/core@7.28.6)':
     dependencies:
-      '@babel/core': 7.28.5
-      '@babel/helper-compilation-targets': 7.27.2
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/core': 7.28.6
+      '@babel/helper-compilation-targets': 7.28.6
+      '@babel/helper-plugin-utils': 7.28.6
       debug: 4.4.3
       lodash.debounce: 4.0.8
       resolve: 1.22.11
@@ -8395,6 +8533,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/helper-module-imports@7.28.6':
+    dependencies:
+      '@babel/traverse': 7.28.6
+      '@babel/types': 7.28.6
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/helper-module-transforms@7.25.2(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
@@ -8414,6 +8559,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/helper-module-transforms@7.28.6(@babel/core@7.28.6)':
+    dependencies:
+      '@babel/core': 7.28.6
+      '@babel/helper-module-imports': 7.28.6
+      '@babel/helper-validator-identifier': 7.28.5
+      '@babel/traverse': 7.28.6
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/helper-optimise-call-expression@7.24.7':
     dependencies:
       '@babel/types': 7.28.5
@@ -8426,12 +8580,14 @@ snapshots:
 
   '@babel/helper-plugin-utils@7.27.1': {}
 
-  '@babel/helper-remap-async-to-generator@7.27.1(@babel/core@7.28.5)':
+  '@babel/helper-plugin-utils@7.28.6': {}
+
+  '@babel/helper-remap-async-to-generator@7.27.1(@babel/core@7.28.6)':
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.28.6
       '@babel/helper-annotate-as-pure': 7.27.3
-      '@babel/helper-wrap-function': 7.28.3
-      '@babel/traverse': 7.28.5
+      '@babel/helper-wrap-function': 7.28.6
+      '@babel/traverse': 7.28.6
     transitivePeerDependencies:
       - supports-color
 
@@ -8450,6 +8606,15 @@ snapshots:
       '@babel/helper-member-expression-to-functions': 7.28.5
       '@babel/helper-optimise-call-expression': 7.27.1
       '@babel/traverse': 7.28.5
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-replace-supers@7.28.6(@babel/core@7.28.6)':
+    dependencies:
+      '@babel/core': 7.28.6
+      '@babel/helper-member-expression-to-functions': 7.28.5
+      '@babel/helper-optimise-call-expression': 7.27.1
+      '@babel/traverse': 7.28.6
     transitivePeerDependencies:
       - supports-color
 
@@ -8490,11 +8655,11 @@ snapshots:
 
   '@babel/helper-validator-option@7.27.1': {}
 
-  '@babel/helper-wrap-function@7.28.3':
+  '@babel/helper-wrap-function@7.28.6':
     dependencies:
-      '@babel/template': 7.27.2
-      '@babel/traverse': 7.28.5
-      '@babel/types': 7.28.5
+      '@babel/template': 7.28.6
+      '@babel/traverse': 7.28.6
+      '@babel/types': 7.28.6
     transitivePeerDependencies:
       - supports-color
 
@@ -8507,6 +8672,11 @@ snapshots:
     dependencies:
       '@babel/template': 7.27.2
       '@babel/types': 7.28.5
+
+  '@babel/helpers@7.28.6':
+    dependencies:
+      '@babel/template': 7.28.6
+      '@babel/types': 7.28.6
 
   '@babel/highlight@7.24.7':
     dependencies:
@@ -8527,38 +8697,42 @@ snapshots:
     dependencies:
       '@babel/types': 7.28.5
 
-  '@babel/plugin-bugfix-firefox-class-in-computed-class-key@7.28.5(@babel/core@7.28.5)':
+  '@babel/parser@7.28.6':
     dependencies:
-      '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
-      '@babel/traverse': 7.28.5
+      '@babel/types': 7.28.6
+
+  '@babel/plugin-bugfix-firefox-class-in-computed-class-key@7.28.5(@babel/core@7.28.6)':
+    dependencies:
+      '@babel/core': 7.28.6
+      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/traverse': 7.28.6
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-bugfix-safari-class-field-initializer-scope@7.27.1(@babel/core@7.28.5)':
+  '@babel/plugin-bugfix-safari-class-field-initializer-scope@7.27.1(@babel/core@7.28.6)':
     dependencies:
-      '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/core': 7.28.6
+      '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.27.1(@babel/core@7.28.5)':
+  '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.27.1(@babel/core@7.28.6)':
     dependencies:
-      '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/core': 7.28.6
+      '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@7.27.1(@babel/core@7.28.5)':
+  '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@7.27.1(@babel/core@7.28.6)':
     dependencies:
-      '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/core': 7.28.6
+      '@babel/helper-plugin-utils': 7.28.6
       '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
-      '@babel/plugin-transform-optional-chaining': 7.28.5(@babel/core@7.28.5)
+      '@babel/plugin-transform-optional-chaining': 7.28.6(@babel/core@7.28.6)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly@7.28.3(@babel/core@7.28.5)':
+  '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly@7.28.6(@babel/core@7.28.6)':
     dependencies:
-      '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
-      '@babel/traverse': 7.28.5
+      '@babel/core': 7.28.6
+      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/traverse': 7.28.6
     transitivePeerDependencies:
       - supports-color
 
@@ -8571,24 +8745,29 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-proposal-private-property-in-object@7.21.0-placeholder-for-preset-env.2(@babel/core@7.28.5)':
+  '@babel/plugin-proposal-private-property-in-object@7.21.0-placeholder-for-preset-env.2(@babel/core@7.28.6)':
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.28.6
 
   '@babel/plugin-syntax-decorators@7.27.1(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-syntax-import-assertions@7.27.1(@babel/core@7.28.5)':
+  '@babel/plugin-syntax-import-assertions@7.28.6(@babel/core@7.28.6)':
     dependencies:
-      '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/core': 7.28.6
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-syntax-import-attributes@7.27.1(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
+
+  '@babel/plugin-syntax-import-attributes@7.28.6(@babel/core@7.28.6)':
+    dependencies:
+      '@babel/core': 7.28.6
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-syntax-import-meta@7.10.4(@babel/core@7.28.5)':
     dependencies:
@@ -8615,169 +8794,169 @@ snapshots:
       '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-syntax-unicode-sets-regex@7.18.6(@babel/core@7.28.5)':
+  '@babel/plugin-syntax-unicode-sets-regex@7.18.6(@babel/core@7.28.6)':
     dependencies:
-      '@babel/core': 7.28.5
-      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.28.5)
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/core': 7.28.6
+      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.28.6)
+      '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-arrow-functions@7.27.1(@babel/core@7.28.5)':
+  '@babel/plugin-transform-arrow-functions@7.27.1(@babel/core@7.28.6)':
     dependencies:
-      '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/core': 7.28.6
+      '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-async-generator-functions@7.28.0(@babel/core@7.28.5)':
+  '@babel/plugin-transform-async-generator-functions@7.28.6(@babel/core@7.28.6)':
     dependencies:
-      '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
-      '@babel/helper-remap-async-to-generator': 7.27.1(@babel/core@7.28.5)
-      '@babel/traverse': 7.28.5
+      '@babel/core': 7.28.6
+      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/helper-remap-async-to-generator': 7.27.1(@babel/core@7.28.6)
+      '@babel/traverse': 7.28.6
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-async-to-generator@7.27.1(@babel/core@7.28.5)':
+  '@babel/plugin-transform-async-to-generator@7.28.6(@babel/core@7.28.6)':
     dependencies:
-      '@babel/core': 7.28.5
-      '@babel/helper-module-imports': 7.27.1
-      '@babel/helper-plugin-utils': 7.27.1
-      '@babel/helper-remap-async-to-generator': 7.27.1(@babel/core@7.28.5)
+      '@babel/core': 7.28.6
+      '@babel/helper-module-imports': 7.28.6
+      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/helper-remap-async-to-generator': 7.27.1(@babel/core@7.28.6)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-block-scoped-functions@7.27.1(@babel/core@7.28.5)':
+  '@babel/plugin-transform-block-scoped-functions@7.27.1(@babel/core@7.28.6)':
     dependencies:
-      '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/core': 7.28.6
+      '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-block-scoping@7.28.5(@babel/core@7.28.5)':
+  '@babel/plugin-transform-block-scoping@7.28.6(@babel/core@7.28.6)':
     dependencies:
-      '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/core': 7.28.6
+      '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-class-properties@7.27.1(@babel/core@7.28.5)':
+  '@babel/plugin-transform-class-properties@7.28.6(@babel/core@7.28.6)':
     dependencies:
-      '@babel/core': 7.28.5
-      '@babel/helper-create-class-features-plugin': 7.28.5(@babel/core@7.28.5)
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/core': 7.28.6
+      '@babel/helper-create-class-features-plugin': 7.28.6(@babel/core@7.28.6)
+      '@babel/helper-plugin-utils': 7.28.6
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-class-static-block@7.28.3(@babel/core@7.28.5)':
+  '@babel/plugin-transform-class-static-block@7.28.6(@babel/core@7.28.6)':
     dependencies:
-      '@babel/core': 7.28.5
-      '@babel/helper-create-class-features-plugin': 7.28.5(@babel/core@7.28.5)
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/core': 7.28.6
+      '@babel/helper-create-class-features-plugin': 7.28.6(@babel/core@7.28.6)
+      '@babel/helper-plugin-utils': 7.28.6
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-classes@7.28.4(@babel/core@7.28.5)':
+  '@babel/plugin-transform-classes@7.28.6(@babel/core@7.28.6)':
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.28.6
       '@babel/helper-annotate-as-pure': 7.27.3
-      '@babel/helper-compilation-targets': 7.27.2
+      '@babel/helper-compilation-targets': 7.28.6
       '@babel/helper-globals': 7.28.0
-      '@babel/helper-plugin-utils': 7.27.1
-      '@babel/helper-replace-supers': 7.27.1(@babel/core@7.28.5)
-      '@babel/traverse': 7.28.5
+      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/helper-replace-supers': 7.28.6(@babel/core@7.28.6)
+      '@babel/traverse': 7.28.6
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-computed-properties@7.27.1(@babel/core@7.28.5)':
+  '@babel/plugin-transform-computed-properties@7.28.6(@babel/core@7.28.6)':
     dependencies:
-      '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
-      '@babel/template': 7.27.2
+      '@babel/core': 7.28.6
+      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/template': 7.28.6
 
-  '@babel/plugin-transform-destructuring@7.28.5(@babel/core@7.28.5)':
+  '@babel/plugin-transform-destructuring@7.28.5(@babel/core@7.28.6)':
     dependencies:
-      '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
-      '@babel/traverse': 7.28.5
+      '@babel/core': 7.28.6
+      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/traverse': 7.28.6
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-dotall-regex@7.27.1(@babel/core@7.28.5)':
+  '@babel/plugin-transform-dotall-regex@7.28.6(@babel/core@7.28.6)':
     dependencies:
-      '@babel/core': 7.28.5
-      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.28.5)
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/core': 7.28.6
+      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.28.6)
+      '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-duplicate-keys@7.27.1(@babel/core@7.28.5)':
+  '@babel/plugin-transform-duplicate-keys@7.27.1(@babel/core@7.28.6)':
     dependencies:
-      '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/core': 7.28.6
+      '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-duplicate-named-capturing-groups-regex@7.27.1(@babel/core@7.28.5)':
+  '@babel/plugin-transform-duplicate-named-capturing-groups-regex@7.28.6(@babel/core@7.28.6)':
     dependencies:
-      '@babel/core': 7.28.5
-      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.28.5)
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/core': 7.28.6
+      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.28.6)
+      '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-dynamic-import@7.27.1(@babel/core@7.28.5)':
+  '@babel/plugin-transform-dynamic-import@7.27.1(@babel/core@7.28.6)':
     dependencies:
-      '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/core': 7.28.6
+      '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-explicit-resource-management@7.28.0(@babel/core@7.28.5)':
+  '@babel/plugin-transform-explicit-resource-management@7.28.6(@babel/core@7.28.6)':
     dependencies:
-      '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
-      '@babel/plugin-transform-destructuring': 7.28.5(@babel/core@7.28.5)
+      '@babel/core': 7.28.6
+      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/plugin-transform-destructuring': 7.28.5(@babel/core@7.28.6)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-exponentiation-operator@7.28.5(@babel/core@7.28.5)':
+  '@babel/plugin-transform-exponentiation-operator@7.28.6(@babel/core@7.28.6)':
     dependencies:
-      '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/core': 7.28.6
+      '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-export-namespace-from@7.27.1(@babel/core@7.28.5)':
+  '@babel/plugin-transform-export-namespace-from@7.27.1(@babel/core@7.28.6)':
     dependencies:
-      '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/core': 7.28.6
+      '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-for-of@7.27.1(@babel/core@7.28.5)':
+  '@babel/plugin-transform-for-of@7.27.1(@babel/core@7.28.6)':
     dependencies:
-      '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/core': 7.28.6
+      '@babel/helper-plugin-utils': 7.28.6
       '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-function-name@7.27.1(@babel/core@7.28.5)':
+  '@babel/plugin-transform-function-name@7.27.1(@babel/core@7.28.6)':
     dependencies:
-      '@babel/core': 7.28.5
-      '@babel/helper-compilation-targets': 7.27.2
-      '@babel/helper-plugin-utils': 7.27.1
-      '@babel/traverse': 7.28.5
+      '@babel/core': 7.28.6
+      '@babel/helper-compilation-targets': 7.28.6
+      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/traverse': 7.28.6
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-json-strings@7.27.1(@babel/core@7.28.5)':
+  '@babel/plugin-transform-json-strings@7.28.6(@babel/core@7.28.6)':
     dependencies:
-      '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/core': 7.28.6
+      '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-literals@7.27.1(@babel/core@7.28.5)':
+  '@babel/plugin-transform-literals@7.27.1(@babel/core@7.28.6)':
     dependencies:
-      '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/core': 7.28.6
+      '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-logical-assignment-operators@7.28.5(@babel/core@7.28.5)':
+  '@babel/plugin-transform-logical-assignment-operators@7.28.6(@babel/core@7.28.6)':
     dependencies:
-      '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/core': 7.28.6
+      '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-member-expression-literals@7.27.1(@babel/core@7.28.5)':
+  '@babel/plugin-transform-member-expression-literals@7.27.1(@babel/core@7.28.6)':
     dependencies:
-      '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/core': 7.28.6
+      '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-modules-amd@7.27.1(@babel/core@7.28.5)':
+  '@babel/plugin-transform-modules-amd@7.27.1(@babel/core@7.28.6)':
     dependencies:
-      '@babel/core': 7.28.5
-      '@babel/helper-module-transforms': 7.28.3(@babel/core@7.28.5)
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/core': 7.28.6
+      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.28.6)
+      '@babel/helper-plugin-utils': 7.28.6
     transitivePeerDependencies:
       - supports-color
 
@@ -8790,155 +8969,155 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-modules-commonjs@7.27.1(@babel/core@7.28.5)':
+  '@babel/plugin-transform-modules-commonjs@7.28.6(@babel/core@7.28.6)':
     dependencies:
-      '@babel/core': 7.28.5
-      '@babel/helper-module-transforms': 7.28.3(@babel/core@7.28.5)
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/core': 7.28.6
+      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.28.6)
+      '@babel/helper-plugin-utils': 7.28.6
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-modules-systemjs@7.28.5(@babel/core@7.28.5)':
+  '@babel/plugin-transform-modules-systemjs@7.28.5(@babel/core@7.28.6)':
     dependencies:
-      '@babel/core': 7.28.5
-      '@babel/helper-module-transforms': 7.28.3(@babel/core@7.28.5)
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/core': 7.28.6
+      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.28.6)
+      '@babel/helper-plugin-utils': 7.28.6
       '@babel/helper-validator-identifier': 7.28.5
-      '@babel/traverse': 7.28.5
+      '@babel/traverse': 7.28.6
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-modules-umd@7.27.1(@babel/core@7.28.5)':
+  '@babel/plugin-transform-modules-umd@7.27.1(@babel/core@7.28.6)':
     dependencies:
-      '@babel/core': 7.28.5
-      '@babel/helper-module-transforms': 7.28.3(@babel/core@7.28.5)
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/core': 7.28.6
+      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.28.6)
+      '@babel/helper-plugin-utils': 7.28.6
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-named-capturing-groups-regex@7.27.1(@babel/core@7.28.5)':
+  '@babel/plugin-transform-named-capturing-groups-regex@7.27.1(@babel/core@7.28.6)':
     dependencies:
-      '@babel/core': 7.28.5
-      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.28.5)
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/core': 7.28.6
+      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.28.6)
+      '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-new-target@7.27.1(@babel/core@7.28.5)':
+  '@babel/plugin-transform-new-target@7.27.1(@babel/core@7.28.6)':
     dependencies:
-      '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/core': 7.28.6
+      '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-nullish-coalescing-operator@7.27.1(@babel/core@7.28.5)':
+  '@babel/plugin-transform-nullish-coalescing-operator@7.28.6(@babel/core@7.28.6)':
     dependencies:
-      '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/core': 7.28.6
+      '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-numeric-separator@7.27.1(@babel/core@7.28.5)':
+  '@babel/plugin-transform-numeric-separator@7.28.6(@babel/core@7.28.6)':
     dependencies:
-      '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/core': 7.28.6
+      '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-object-rest-spread@7.28.4(@babel/core@7.28.5)':
+  '@babel/plugin-transform-object-rest-spread@7.28.6(@babel/core@7.28.6)':
     dependencies:
-      '@babel/core': 7.28.5
-      '@babel/helper-compilation-targets': 7.27.2
-      '@babel/helper-plugin-utils': 7.27.1
-      '@babel/plugin-transform-destructuring': 7.28.5(@babel/core@7.28.5)
-      '@babel/plugin-transform-parameters': 7.27.7(@babel/core@7.28.5)
-      '@babel/traverse': 7.28.5
+      '@babel/core': 7.28.6
+      '@babel/helper-compilation-targets': 7.28.6
+      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/plugin-transform-destructuring': 7.28.5(@babel/core@7.28.6)
+      '@babel/plugin-transform-parameters': 7.27.7(@babel/core@7.28.6)
+      '@babel/traverse': 7.28.6
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-object-super@7.27.1(@babel/core@7.28.5)':
+  '@babel/plugin-transform-object-super@7.27.1(@babel/core@7.28.6)':
     dependencies:
-      '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
-      '@babel/helper-replace-supers': 7.27.1(@babel/core@7.28.5)
+      '@babel/core': 7.28.6
+      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/helper-replace-supers': 7.28.6(@babel/core@7.28.6)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-optional-catch-binding@7.27.1(@babel/core@7.28.5)':
+  '@babel/plugin-transform-optional-catch-binding@7.28.6(@babel/core@7.28.6)':
     dependencies:
-      '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/core': 7.28.6
+      '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-optional-chaining@7.28.5(@babel/core@7.28.5)':
+  '@babel/plugin-transform-optional-chaining@7.28.6(@babel/core@7.28.6)':
     dependencies:
-      '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/core': 7.28.6
+      '@babel/helper-plugin-utils': 7.28.6
       '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-parameters@7.27.7(@babel/core@7.28.5)':
+  '@babel/plugin-transform-parameters@7.27.7(@babel/core@7.28.6)':
     dependencies:
-      '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/core': 7.28.6
+      '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-private-methods@7.27.1(@babel/core@7.28.5)':
+  '@babel/plugin-transform-private-methods@7.28.6(@babel/core@7.28.6)':
     dependencies:
-      '@babel/core': 7.28.5
-      '@babel/helper-create-class-features-plugin': 7.28.5(@babel/core@7.28.5)
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/core': 7.28.6
+      '@babel/helper-create-class-features-plugin': 7.28.6(@babel/core@7.28.6)
+      '@babel/helper-plugin-utils': 7.28.6
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-private-property-in-object@7.27.1(@babel/core@7.28.5)':
+  '@babel/plugin-transform-private-property-in-object@7.28.6(@babel/core@7.28.6)':
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.28.6
       '@babel/helper-annotate-as-pure': 7.27.3
-      '@babel/helper-create-class-features-plugin': 7.28.5(@babel/core@7.28.5)
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-create-class-features-plugin': 7.28.6(@babel/core@7.28.6)
+      '@babel/helper-plugin-utils': 7.28.6
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-property-literals@7.27.1(@babel/core@7.28.5)':
+  '@babel/plugin-transform-property-literals@7.27.1(@babel/core@7.28.6)':
     dependencies:
-      '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/core': 7.28.6
+      '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-regenerator@7.28.4(@babel/core@7.28.5)':
+  '@babel/plugin-transform-regenerator@7.28.6(@babel/core@7.28.6)':
     dependencies:
-      '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/core': 7.28.6
+      '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-regexp-modifiers@7.27.1(@babel/core@7.28.5)':
+  '@babel/plugin-transform-regexp-modifiers@7.28.6(@babel/core@7.28.6)':
     dependencies:
-      '@babel/core': 7.28.5
-      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.28.5)
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/core': 7.28.6
+      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.28.6)
+      '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-reserved-words@7.27.1(@babel/core@7.28.5)':
+  '@babel/plugin-transform-reserved-words@7.27.1(@babel/core@7.28.6)':
     dependencies:
-      '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/core': 7.28.6
+      '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-shorthand-properties@7.27.1(@babel/core@7.28.5)':
+  '@babel/plugin-transform-shorthand-properties@7.27.1(@babel/core@7.28.6)':
     dependencies:
-      '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/core': 7.28.6
+      '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-spread@7.27.1(@babel/core@7.28.5)':
+  '@babel/plugin-transform-spread@7.28.6(@babel/core@7.28.6)':
     dependencies:
-      '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/core': 7.28.6
+      '@babel/helper-plugin-utils': 7.28.6
       '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-sticky-regex@7.27.1(@babel/core@7.28.5)':
+  '@babel/plugin-transform-sticky-regex@7.27.1(@babel/core@7.28.6)':
     dependencies:
-      '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/core': 7.28.6
+      '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-template-literals@7.27.1(@babel/core@7.28.5)':
+  '@babel/plugin-transform-template-literals@7.27.1(@babel/core@7.28.6)':
     dependencies:
-      '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/core': 7.28.6
+      '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-typeof-symbol@7.27.1(@babel/core@7.28.5)':
+  '@babel/plugin-transform-typeof-symbol@7.27.1(@babel/core@7.28.6)':
     dependencies:
-      '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/core': 7.28.6
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-transform-typescript@7.24.8(@babel/core@7.25.2)':
     dependencies:
@@ -8961,110 +9140,110 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-unicode-escapes@7.27.1(@babel/core@7.28.5)':
+  '@babel/plugin-transform-unicode-escapes@7.27.1(@babel/core@7.28.6)':
     dependencies:
-      '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/core': 7.28.6
+      '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-unicode-property-regex@7.27.1(@babel/core@7.28.5)':
+  '@babel/plugin-transform-unicode-property-regex@7.28.6(@babel/core@7.28.6)':
     dependencies:
-      '@babel/core': 7.28.5
-      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.28.5)
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/core': 7.28.6
+      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.28.6)
+      '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-unicode-regex@7.27.1(@babel/core@7.28.5)':
+  '@babel/plugin-transform-unicode-regex@7.27.1(@babel/core@7.28.6)':
     dependencies:
-      '@babel/core': 7.28.5
-      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.28.5)
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/core': 7.28.6
+      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.28.6)
+      '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-unicode-sets-regex@7.27.1(@babel/core@7.28.5)':
+  '@babel/plugin-transform-unicode-sets-regex@7.28.6(@babel/core@7.28.6)':
     dependencies:
-      '@babel/core': 7.28.5
-      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.28.5)
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/core': 7.28.6
+      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.28.6)
+      '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/preset-env@7.28.5(@babel/core@7.28.5)':
+  '@babel/preset-env@7.28.6(@babel/core@7.28.6)':
     dependencies:
-      '@babel/compat-data': 7.28.5
-      '@babel/core': 7.28.5
-      '@babel/helper-compilation-targets': 7.27.2
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/compat-data': 7.28.6
+      '@babel/core': 7.28.6
+      '@babel/helper-compilation-targets': 7.28.6
+      '@babel/helper-plugin-utils': 7.28.6
       '@babel/helper-validator-option': 7.27.1
-      '@babel/plugin-bugfix-firefox-class-in-computed-class-key': 7.28.5(@babel/core@7.28.5)
-      '@babel/plugin-bugfix-safari-class-field-initializer-scope': 7.27.1(@babel/core@7.28.5)
-      '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression': 7.27.1(@babel/core@7.28.5)
-      '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining': 7.27.1(@babel/core@7.28.5)
-      '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly': 7.28.3(@babel/core@7.28.5)
-      '@babel/plugin-proposal-private-property-in-object': 7.21.0-placeholder-for-preset-env.2(@babel/core@7.28.5)
-      '@babel/plugin-syntax-import-assertions': 7.27.1(@babel/core@7.28.5)
-      '@babel/plugin-syntax-import-attributes': 7.27.1(@babel/core@7.28.5)
-      '@babel/plugin-syntax-unicode-sets-regex': 7.18.6(@babel/core@7.28.5)
-      '@babel/plugin-transform-arrow-functions': 7.27.1(@babel/core@7.28.5)
-      '@babel/plugin-transform-async-generator-functions': 7.28.0(@babel/core@7.28.5)
-      '@babel/plugin-transform-async-to-generator': 7.27.1(@babel/core@7.28.5)
-      '@babel/plugin-transform-block-scoped-functions': 7.27.1(@babel/core@7.28.5)
-      '@babel/plugin-transform-block-scoping': 7.28.5(@babel/core@7.28.5)
-      '@babel/plugin-transform-class-properties': 7.27.1(@babel/core@7.28.5)
-      '@babel/plugin-transform-class-static-block': 7.28.3(@babel/core@7.28.5)
-      '@babel/plugin-transform-classes': 7.28.4(@babel/core@7.28.5)
-      '@babel/plugin-transform-computed-properties': 7.27.1(@babel/core@7.28.5)
-      '@babel/plugin-transform-destructuring': 7.28.5(@babel/core@7.28.5)
-      '@babel/plugin-transform-dotall-regex': 7.27.1(@babel/core@7.28.5)
-      '@babel/plugin-transform-duplicate-keys': 7.27.1(@babel/core@7.28.5)
-      '@babel/plugin-transform-duplicate-named-capturing-groups-regex': 7.27.1(@babel/core@7.28.5)
-      '@babel/plugin-transform-dynamic-import': 7.27.1(@babel/core@7.28.5)
-      '@babel/plugin-transform-explicit-resource-management': 7.28.0(@babel/core@7.28.5)
-      '@babel/plugin-transform-exponentiation-operator': 7.28.5(@babel/core@7.28.5)
-      '@babel/plugin-transform-export-namespace-from': 7.27.1(@babel/core@7.28.5)
-      '@babel/plugin-transform-for-of': 7.27.1(@babel/core@7.28.5)
-      '@babel/plugin-transform-function-name': 7.27.1(@babel/core@7.28.5)
-      '@babel/plugin-transform-json-strings': 7.27.1(@babel/core@7.28.5)
-      '@babel/plugin-transform-literals': 7.27.1(@babel/core@7.28.5)
-      '@babel/plugin-transform-logical-assignment-operators': 7.28.5(@babel/core@7.28.5)
-      '@babel/plugin-transform-member-expression-literals': 7.27.1(@babel/core@7.28.5)
-      '@babel/plugin-transform-modules-amd': 7.27.1(@babel/core@7.28.5)
-      '@babel/plugin-transform-modules-commonjs': 7.27.1(@babel/core@7.28.5)
-      '@babel/plugin-transform-modules-systemjs': 7.28.5(@babel/core@7.28.5)
-      '@babel/plugin-transform-modules-umd': 7.27.1(@babel/core@7.28.5)
-      '@babel/plugin-transform-named-capturing-groups-regex': 7.27.1(@babel/core@7.28.5)
-      '@babel/plugin-transform-new-target': 7.27.1(@babel/core@7.28.5)
-      '@babel/plugin-transform-nullish-coalescing-operator': 7.27.1(@babel/core@7.28.5)
-      '@babel/plugin-transform-numeric-separator': 7.27.1(@babel/core@7.28.5)
-      '@babel/plugin-transform-object-rest-spread': 7.28.4(@babel/core@7.28.5)
-      '@babel/plugin-transform-object-super': 7.27.1(@babel/core@7.28.5)
-      '@babel/plugin-transform-optional-catch-binding': 7.27.1(@babel/core@7.28.5)
-      '@babel/plugin-transform-optional-chaining': 7.28.5(@babel/core@7.28.5)
-      '@babel/plugin-transform-parameters': 7.27.7(@babel/core@7.28.5)
-      '@babel/plugin-transform-private-methods': 7.27.1(@babel/core@7.28.5)
-      '@babel/plugin-transform-private-property-in-object': 7.27.1(@babel/core@7.28.5)
-      '@babel/plugin-transform-property-literals': 7.27.1(@babel/core@7.28.5)
-      '@babel/plugin-transform-regenerator': 7.28.4(@babel/core@7.28.5)
-      '@babel/plugin-transform-regexp-modifiers': 7.27.1(@babel/core@7.28.5)
-      '@babel/plugin-transform-reserved-words': 7.27.1(@babel/core@7.28.5)
-      '@babel/plugin-transform-shorthand-properties': 7.27.1(@babel/core@7.28.5)
-      '@babel/plugin-transform-spread': 7.27.1(@babel/core@7.28.5)
-      '@babel/plugin-transform-sticky-regex': 7.27.1(@babel/core@7.28.5)
-      '@babel/plugin-transform-template-literals': 7.27.1(@babel/core@7.28.5)
-      '@babel/plugin-transform-typeof-symbol': 7.27.1(@babel/core@7.28.5)
-      '@babel/plugin-transform-unicode-escapes': 7.27.1(@babel/core@7.28.5)
-      '@babel/plugin-transform-unicode-property-regex': 7.27.1(@babel/core@7.28.5)
-      '@babel/plugin-transform-unicode-regex': 7.27.1(@babel/core@7.28.5)
-      '@babel/plugin-transform-unicode-sets-regex': 7.27.1(@babel/core@7.28.5)
-      '@babel/preset-modules': 0.1.6-no-external-plugins(@babel/core@7.28.5)
-      babel-plugin-polyfill-corejs2: 0.4.14(@babel/core@7.28.5)
-      babel-plugin-polyfill-corejs3: 0.13.0(@babel/core@7.28.5)
-      babel-plugin-polyfill-regenerator: 0.6.5(@babel/core@7.28.5)
+      '@babel/plugin-bugfix-firefox-class-in-computed-class-key': 7.28.5(@babel/core@7.28.6)
+      '@babel/plugin-bugfix-safari-class-field-initializer-scope': 7.27.1(@babel/core@7.28.6)
+      '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression': 7.27.1(@babel/core@7.28.6)
+      '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining': 7.27.1(@babel/core@7.28.6)
+      '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly': 7.28.6(@babel/core@7.28.6)
+      '@babel/plugin-proposal-private-property-in-object': 7.21.0-placeholder-for-preset-env.2(@babel/core@7.28.6)
+      '@babel/plugin-syntax-import-assertions': 7.28.6(@babel/core@7.28.6)
+      '@babel/plugin-syntax-import-attributes': 7.28.6(@babel/core@7.28.6)
+      '@babel/plugin-syntax-unicode-sets-regex': 7.18.6(@babel/core@7.28.6)
+      '@babel/plugin-transform-arrow-functions': 7.27.1(@babel/core@7.28.6)
+      '@babel/plugin-transform-async-generator-functions': 7.28.6(@babel/core@7.28.6)
+      '@babel/plugin-transform-async-to-generator': 7.28.6(@babel/core@7.28.6)
+      '@babel/plugin-transform-block-scoped-functions': 7.27.1(@babel/core@7.28.6)
+      '@babel/plugin-transform-block-scoping': 7.28.6(@babel/core@7.28.6)
+      '@babel/plugin-transform-class-properties': 7.28.6(@babel/core@7.28.6)
+      '@babel/plugin-transform-class-static-block': 7.28.6(@babel/core@7.28.6)
+      '@babel/plugin-transform-classes': 7.28.6(@babel/core@7.28.6)
+      '@babel/plugin-transform-computed-properties': 7.28.6(@babel/core@7.28.6)
+      '@babel/plugin-transform-destructuring': 7.28.5(@babel/core@7.28.6)
+      '@babel/plugin-transform-dotall-regex': 7.28.6(@babel/core@7.28.6)
+      '@babel/plugin-transform-duplicate-keys': 7.27.1(@babel/core@7.28.6)
+      '@babel/plugin-transform-duplicate-named-capturing-groups-regex': 7.28.6(@babel/core@7.28.6)
+      '@babel/plugin-transform-dynamic-import': 7.27.1(@babel/core@7.28.6)
+      '@babel/plugin-transform-explicit-resource-management': 7.28.6(@babel/core@7.28.6)
+      '@babel/plugin-transform-exponentiation-operator': 7.28.6(@babel/core@7.28.6)
+      '@babel/plugin-transform-export-namespace-from': 7.27.1(@babel/core@7.28.6)
+      '@babel/plugin-transform-for-of': 7.27.1(@babel/core@7.28.6)
+      '@babel/plugin-transform-function-name': 7.27.1(@babel/core@7.28.6)
+      '@babel/plugin-transform-json-strings': 7.28.6(@babel/core@7.28.6)
+      '@babel/plugin-transform-literals': 7.27.1(@babel/core@7.28.6)
+      '@babel/plugin-transform-logical-assignment-operators': 7.28.6(@babel/core@7.28.6)
+      '@babel/plugin-transform-member-expression-literals': 7.27.1(@babel/core@7.28.6)
+      '@babel/plugin-transform-modules-amd': 7.27.1(@babel/core@7.28.6)
+      '@babel/plugin-transform-modules-commonjs': 7.28.6(@babel/core@7.28.6)
+      '@babel/plugin-transform-modules-systemjs': 7.28.5(@babel/core@7.28.6)
+      '@babel/plugin-transform-modules-umd': 7.27.1(@babel/core@7.28.6)
+      '@babel/plugin-transform-named-capturing-groups-regex': 7.27.1(@babel/core@7.28.6)
+      '@babel/plugin-transform-new-target': 7.27.1(@babel/core@7.28.6)
+      '@babel/plugin-transform-nullish-coalescing-operator': 7.28.6(@babel/core@7.28.6)
+      '@babel/plugin-transform-numeric-separator': 7.28.6(@babel/core@7.28.6)
+      '@babel/plugin-transform-object-rest-spread': 7.28.6(@babel/core@7.28.6)
+      '@babel/plugin-transform-object-super': 7.27.1(@babel/core@7.28.6)
+      '@babel/plugin-transform-optional-catch-binding': 7.28.6(@babel/core@7.28.6)
+      '@babel/plugin-transform-optional-chaining': 7.28.6(@babel/core@7.28.6)
+      '@babel/plugin-transform-parameters': 7.27.7(@babel/core@7.28.6)
+      '@babel/plugin-transform-private-methods': 7.28.6(@babel/core@7.28.6)
+      '@babel/plugin-transform-private-property-in-object': 7.28.6(@babel/core@7.28.6)
+      '@babel/plugin-transform-property-literals': 7.27.1(@babel/core@7.28.6)
+      '@babel/plugin-transform-regenerator': 7.28.6(@babel/core@7.28.6)
+      '@babel/plugin-transform-regexp-modifiers': 7.28.6(@babel/core@7.28.6)
+      '@babel/plugin-transform-reserved-words': 7.27.1(@babel/core@7.28.6)
+      '@babel/plugin-transform-shorthand-properties': 7.27.1(@babel/core@7.28.6)
+      '@babel/plugin-transform-spread': 7.28.6(@babel/core@7.28.6)
+      '@babel/plugin-transform-sticky-regex': 7.27.1(@babel/core@7.28.6)
+      '@babel/plugin-transform-template-literals': 7.27.1(@babel/core@7.28.6)
+      '@babel/plugin-transform-typeof-symbol': 7.27.1(@babel/core@7.28.6)
+      '@babel/plugin-transform-unicode-escapes': 7.27.1(@babel/core@7.28.6)
+      '@babel/plugin-transform-unicode-property-regex': 7.28.6(@babel/core@7.28.6)
+      '@babel/plugin-transform-unicode-regex': 7.27.1(@babel/core@7.28.6)
+      '@babel/plugin-transform-unicode-sets-regex': 7.28.6(@babel/core@7.28.6)
+      '@babel/preset-modules': 0.1.6-no-external-plugins(@babel/core@7.28.6)
+      babel-plugin-polyfill-corejs2: 0.4.14(@babel/core@7.28.6)
+      babel-plugin-polyfill-corejs3: 0.13.0(@babel/core@7.28.6)
+      babel-plugin-polyfill-regenerator: 0.6.5(@babel/core@7.28.6)
       core-js-compat: 3.47.0
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/preset-modules@0.1.6-no-external-plugins(@babel/core@7.28.5)':
+  '@babel/preset-modules@0.1.6-no-external-plugins(@babel/core@7.28.6)':
     dependencies:
-      '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
-      '@babel/types': 7.28.5
+      '@babel/core': 7.28.6
+      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/types': 7.28.6
       esutils: 2.0.3
 
   '@babel/preset-typescript@7.24.7(@babel/core@7.25.2)':
@@ -9082,7 +9261,7 @@ snapshots:
     dependencies:
       regenerator-runtime: 0.13.11
 
-  '@babel/runtime@7.28.4': {}
+  '@babel/runtime@7.28.6': {}
 
   '@babel/standalone@7.28.5': {}
 
@@ -9097,6 +9276,12 @@ snapshots:
       '@babel/code-frame': 7.27.1
       '@babel/parser': 7.28.5
       '@babel/types': 7.28.5
+
+  '@babel/template@7.28.6':
+    dependencies:
+      '@babel/code-frame': 7.28.6
+      '@babel/parser': 7.28.6
+      '@babel/types': 7.28.6
 
   '@babel/traverse@7.25.3':
     dependencies:
@@ -9134,6 +9319,18 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/traverse@7.28.6':
+    dependencies:
+      '@babel/code-frame': 7.28.6
+      '@babel/generator': 7.28.6
+      '@babel/helper-globals': 7.28.0
+      '@babel/parser': 7.28.6
+      '@babel/template': 7.28.6
+      '@babel/types': 7.28.6
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/types@7.25.2':
     dependencies:
       '@babel/helper-string-parser': 7.24.8
@@ -9141,6 +9338,11 @@ snapshots:
       to-fast-properties: 2.0.0
 
   '@babel/types@7.28.5':
+    dependencies:
+      '@babel/helper-string-parser': 7.27.1
+      '@babel/helper-validator-identifier': 7.28.5
+
+  '@babel/types@7.28.6':
     dependencies:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
@@ -9481,7 +9683,7 @@ snapshots:
   '@eslint/eslintrc@2.1.3':
     dependencies:
       ajv: 6.12.6
-      debug: 4.3.6
+      debug: 4.4.3
       espree: 9.6.1
       globals: 13.20.0
       ignore: 5.3.1
@@ -9512,7 +9714,7 @@ snapshots:
   '@humanwhocodes/config-array@0.11.13':
     dependencies:
       '@humanwhocodes/object-schema': 2.0.1
-      debug: 4.3.6
+      debug: 4.4.3
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
@@ -9538,7 +9740,7 @@ snapshots:
       '@iconify/types': 2.0.0
       debug: 4.4.3
       kolorist: 1.8.0
-      local-pkg: 0.5.0
+      local-pkg: 0.5.1
       mlly: 1.8.0
     transitivePeerDependencies:
       - supports-color
@@ -9825,40 +10027,40 @@ snapshots:
 
   '@nuxt/devalue@2.0.2': {}
 
-  '@nuxt/devtools-kit@1.7.0(magicast@0.3.5)(vite@6.4.1(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2))':
+  '@nuxt/devtools-kit@1.7.0(magicast@0.3.5)(vite@6.4.1(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2))':
     dependencies:
       '@nuxt/kit': 3.15.4(magicast@0.3.5)
       '@nuxt/schema': 3.15.4
       execa: 7.2.0
-      vite: 6.4.1(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2)
+      vite: 6.4.1(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2)
     transitivePeerDependencies:
       - magicast
       - supports-color
 
-  '@nuxt/devtools-kit@1.7.0(magicast@0.3.5)(vite@6.4.1(@types/node@25.0.2)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2))':
+  '@nuxt/devtools-kit@1.7.0(magicast@0.3.5)(vite@6.4.1(@types/node@25.0.2)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2))':
     dependencies:
       '@nuxt/kit': 3.15.4(magicast@0.3.5)
       '@nuxt/schema': 3.15.4
       execa: 7.2.0
-      vite: 6.4.1(@types/node@25.0.2)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2)
+      vite: 6.4.1(@types/node@25.0.2)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2)
     transitivePeerDependencies:
       - magicast
       - supports-color
 
-  '@nuxt/devtools-kit@3.1.1(magicast@0.5.1)(vite@6.4.1(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2))':
+  '@nuxt/devtools-kit@3.1.1(magicast@0.5.1)(vite@6.4.1(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2))':
     dependencies:
       '@nuxt/kit': 3.15.4(magicast@0.5.1)
       execa: 8.0.1
-      vite: 6.4.1(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2)
+      vite: 6.4.1(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2)
     transitivePeerDependencies:
       - magicast
       - supports-color
 
-  '@nuxt/devtools-kit@3.1.1(magicast@0.5.1)(vite@6.4.1(@types/node@25.0.2)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2))':
+  '@nuxt/devtools-kit@3.1.1(magicast@0.5.1)(vite@6.4.1(@types/node@25.0.2)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2))':
     dependencies:
       '@nuxt/kit': 3.15.4(magicast@0.5.1)
       execa: 8.0.1
-      vite: 6.4.1(@types/node@25.0.2)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2)
+      vite: 6.4.1(@types/node@25.0.2)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2)
     transitivePeerDependencies:
       - magicast
       - supports-color
@@ -9887,13 +10089,13 @@ snapshots:
       prompts: 2.4.2
       semver: 7.7.3
 
-  '@nuxt/devtools@1.7.0(rollup@4.53.4)(vite@6.4.1(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2))(vue@3.4.31(typescript@5.5.4))':
+  '@nuxt/devtools@1.7.0(rollup@4.53.4)(vite@6.4.1(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2))(vue@3.4.31(typescript@5.5.4))':
     dependencies:
       '@antfu/utils': 0.7.10
-      '@nuxt/devtools-kit': 1.7.0(magicast@0.3.5)(vite@6.4.1(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2))
+      '@nuxt/devtools-kit': 1.7.0(magicast@0.3.5)(vite@6.4.1(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2))
       '@nuxt/devtools-wizard': 1.7.0
       '@nuxt/kit': 3.15.4(magicast@0.3.5)
-      '@vue/devtools-core': 7.6.8(vite@6.4.1(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2))(vue@3.4.31(typescript@5.5.4))
+      '@vue/devtools-core': 7.6.8(vite@6.4.1(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2))(vue@3.4.31(typescript@5.5.4))
       '@vue/devtools-kit': 7.6.8
       birpc: 0.2.19
       consola: 3.4.2
@@ -9922,9 +10124,9 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.10
       unimport: 3.14.6(rollup@4.53.4)
-      vite: 6.4.1(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2)
-      vite-plugin-inspect: 0.8.9(@nuxt/kit@3.15.4(magicast@0.5.1))(rollup@4.53.4)(vite@6.4.1(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2))
-      vite-plugin-vue-inspector: 5.3.2(vite@6.4.1(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2))
+      vite: 6.4.1(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2)
+      vite-plugin-inspect: 0.8.9(@nuxt/kit@3.15.4(magicast@0.5.1))(rollup@4.53.4)(vite@6.4.1(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2))
+      vite-plugin-vue-inspector: 5.3.2(vite@6.4.1(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2))
       which: 3.0.1
       ws: 8.18.3
     transitivePeerDependencies:
@@ -9934,13 +10136,13 @@ snapshots:
       - utf-8-validate
       - vue
 
-  '@nuxt/devtools@1.7.0(rollup@4.53.4)(vite@6.4.1(@types/node@25.0.2)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2))(vue@3.4.31(typescript@5.5.4))':
+  '@nuxt/devtools@1.7.0(rollup@4.53.4)(vite@6.4.1(@types/node@25.0.2)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2))(vue@3.4.31(typescript@5.5.4))':
     dependencies:
       '@antfu/utils': 0.7.10
-      '@nuxt/devtools-kit': 1.7.0(magicast@0.3.5)(vite@6.4.1(@types/node@25.0.2)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2))
+      '@nuxt/devtools-kit': 1.7.0(magicast@0.3.5)(vite@6.4.1(@types/node@25.0.2)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2))
       '@nuxt/devtools-wizard': 1.7.0
       '@nuxt/kit': 3.15.4(magicast@0.3.5)
-      '@vue/devtools-core': 7.6.8(vite@6.4.1(@types/node@25.0.2)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2))(vue@3.4.31(typescript@5.5.4))
+      '@vue/devtools-core': 7.6.8(vite@6.4.1(@types/node@25.0.2)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2))(vue@3.4.31(typescript@5.5.4))
       '@vue/devtools-kit': 7.6.8
       birpc: 0.2.19
       consola: 3.4.2
@@ -9969,9 +10171,9 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.10
       unimport: 3.14.6(rollup@4.53.4)
-      vite: 6.4.1(@types/node@25.0.2)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2)
-      vite-plugin-inspect: 0.8.9(@nuxt/kit@3.15.4(magicast@0.5.1))(rollup@4.53.4)(vite@6.4.1(@types/node@25.0.2)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2))
-      vite-plugin-vue-inspector: 5.3.2(vite@6.4.1(@types/node@25.0.2)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2))
+      vite: 6.4.1(@types/node@25.0.2)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2)
+      vite-plugin-inspect: 0.8.9(@nuxt/kit@3.15.4(magicast@0.5.1))(rollup@4.53.4)(vite@6.4.1(@types/node@25.0.2)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2))
+      vite-plugin-vue-inspector: 5.3.2(vite@6.4.1(@types/node@25.0.2)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2))
       which: 3.0.1
       ws: 8.18.3
     transitivePeerDependencies:
@@ -9981,12 +10183,12 @@ snapshots:
       - utf-8-validate
       - vue
 
-  '@nuxt/devtools@3.1.1(vite@6.4.1(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2))(vue@3.4.31(typescript@5.5.4))':
+  '@nuxt/devtools@3.1.1(vite@6.4.1(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2))(vue@3.4.31(typescript@5.5.4))':
     dependencies:
-      '@nuxt/devtools-kit': 3.1.1(magicast@0.5.1)(vite@6.4.1(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2))
+      '@nuxt/devtools-kit': 3.1.1(magicast@0.5.1)(vite@6.4.1(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2))
       '@nuxt/devtools-wizard': 3.1.1
       '@nuxt/kit': 3.15.4(magicast@0.5.1)
-      '@vue/devtools-core': 8.0.5(vite@6.4.1(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2))(vue@3.4.31(typescript@5.5.4))
+      '@vue/devtools-core': 8.0.5(vite@6.4.1(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2))(vue@3.4.31(typescript@5.5.4))
       '@vue/devtools-kit': 8.0.5
       birpc: 2.9.0
       consola: 3.4.2
@@ -10011,9 +10213,9 @@ snapshots:
       sirv: 3.0.2
       structured-clone-es: 1.0.0
       tinyglobby: 0.2.15
-      vite: 6.4.1(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2)
-      vite-plugin-inspect: 11.3.3(@nuxt/kit@3.15.4(magicast@0.5.1))(vite@6.4.1(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2))
-      vite-plugin-vue-tracer: 1.1.3(vite@6.4.1(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2))(vue@3.4.31(typescript@5.5.4))
+      vite: 6.4.1(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2)
+      vite-plugin-inspect: 11.3.3(@nuxt/kit@3.15.4(magicast@0.5.1))(vite@6.4.1(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2))
+      vite-plugin-vue-tracer: 1.1.3(vite@6.4.1(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2))(vue@3.4.31(typescript@5.5.4))
       which: 5.0.0
       ws: 8.18.3
     transitivePeerDependencies:
@@ -10022,12 +10224,12 @@ snapshots:
       - utf-8-validate
       - vue
 
-  '@nuxt/devtools@3.1.1(vite@6.4.1(@types/node@25.0.2)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2))(vue@3.4.31(typescript@5.5.4))':
+  '@nuxt/devtools@3.1.1(vite@6.4.1(@types/node@25.0.2)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2))(vue@3.4.31(typescript@5.5.4))':
     dependencies:
-      '@nuxt/devtools-kit': 3.1.1(magicast@0.5.1)(vite@6.4.1(@types/node@25.0.2)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2))
+      '@nuxt/devtools-kit': 3.1.1(magicast@0.5.1)(vite@6.4.1(@types/node@25.0.2)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2))
       '@nuxt/devtools-wizard': 3.1.1
       '@nuxt/kit': 3.15.4(magicast@0.5.1)
-      '@vue/devtools-core': 8.0.5(vite@6.4.1(@types/node@25.0.2)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2))(vue@3.4.31(typescript@5.5.4))
+      '@vue/devtools-core': 8.0.5(vite@6.4.1(@types/node@25.0.2)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2))(vue@3.4.31(typescript@5.5.4))
       '@vue/devtools-kit': 8.0.5
       birpc: 2.9.0
       consola: 3.4.2
@@ -10052,9 +10254,9 @@ snapshots:
       sirv: 3.0.2
       structured-clone-es: 1.0.0
       tinyglobby: 0.2.15
-      vite: 6.4.1(@types/node@25.0.2)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2)
-      vite-plugin-inspect: 11.3.3(@nuxt/kit@3.15.4(magicast@0.5.1))(vite@6.4.1(@types/node@25.0.2)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2))
-      vite-plugin-vue-tracer: 1.1.3(vite@6.4.1(@types/node@25.0.2)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2))(vue@3.4.31(typescript@5.5.4))
+      vite: 6.4.1(@types/node@25.0.2)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2)
+      vite-plugin-inspect: 11.3.3(@nuxt/kit@3.15.4(magicast@0.5.1))(vite@6.4.1(@types/node@25.0.2)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2))
+      vite-plugin-vue-tracer: 1.1.3(vite@6.4.1(@types/node@25.0.2)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2))(vue@3.4.31(typescript@5.5.4))
       which: 5.0.0
       ws: 8.18.3
     transitivePeerDependencies:
@@ -10115,7 +10317,7 @@ snapshots:
       - magicast
       - supports-color
 
-  '@nuxt/module-builder@1.0.2(@nuxt/cli@3.31.2(cac@6.7.14)(magicast@0.5.1))(@vue/compiler-core@3.5.25)(esbuild@0.23.0)(sass@1.77.8)(typescript@5.5.4)(vue-tsc@2.1.10(typescript@5.5.4))(vue@3.4.31(typescript@5.5.4))':
+  '@nuxt/module-builder@1.0.2(@nuxt/cli@3.31.2(cac@6.7.14)(magicast@0.5.1))(@vue/compiler-core@3.5.25)(esbuild@0.25.12)(sass@1.77.8)(typescript@5.5.4)(vue-tsc@2.1.10(typescript@5.5.4))(vue@3.4.31(typescript@5.5.4))':
     dependencies:
       '@nuxt/cli': 3.31.2(cac@6.7.14)(magicast@0.5.1)
       citty: 0.1.6
@@ -10123,14 +10325,14 @@ snapshots:
       defu: 6.1.4
       jiti: 2.6.1
       magic-regexp: 0.10.0
-      mkdist: 2.4.1(sass@1.77.8)(typescript@5.5.4)(vue-sfc-transformer@0.1.17(@vue/compiler-core@3.5.25)(esbuild@0.23.0)(vue@3.4.31(typescript@5.5.4)))(vue-tsc@2.1.10(typescript@5.5.4))(vue@3.4.31(typescript@5.5.4))
+      mkdist: 2.4.1(sass@1.77.8)(typescript@5.5.4)(vue-sfc-transformer@0.1.17(@vue/compiler-core@3.5.25)(esbuild@0.25.12)(vue@3.4.31(typescript@5.5.4)))(vue-tsc@2.1.10(typescript@5.5.4))(vue@3.4.31(typescript@5.5.4))
       mlly: 1.8.0
       pathe: 2.0.3
       pkg-types: 2.3.0
       tsconfck: 3.1.6(typescript@5.5.4)
       typescript: 5.5.4
-      unbuild: 3.6.1(sass@1.77.8)(typescript@5.5.4)(vue-sfc-transformer@0.1.17(@vue/compiler-core@3.5.25)(esbuild@0.23.0)(vue@3.4.31(typescript@5.5.4)))(vue-tsc@2.1.10(typescript@5.5.4))(vue@3.4.31(typescript@5.5.4))
-      vue-sfc-transformer: 0.1.17(@vue/compiler-core@3.5.25)(esbuild@0.23.0)(vue@3.4.31(typescript@5.5.4))
+      unbuild: 3.6.1(sass@1.77.8)(typescript@5.5.4)(vue-sfc-transformer@0.1.17(@vue/compiler-core@3.5.25)(esbuild@0.25.12)(vue@3.4.31(typescript@5.5.4)))(vue-tsc@2.1.10(typescript@5.5.4))(vue@3.4.31(typescript@5.5.4))
+      vue-sfc-transformer: 0.1.17(@vue/compiler-core@3.5.25)(esbuild@0.25.12)(vue@3.4.31(typescript@5.5.4))
     transitivePeerDependencies:
       - '@vue/compiler-core'
       - esbuild
@@ -10181,7 +10383,7 @@ snapshots:
       - magicast
       - supports-color
 
-  '@nuxt/test-utils@3.13.1(h3@1.15.4)(magicast@0.5.1)(nitropack@2.12.9(encoding@0.1.13))(vite@6.4.1(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2))(vitest@3.2.4(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2))(vue-router@4.6.4(vue@3.4.31(typescript@5.5.4)))(vue@3.4.31(typescript@5.5.4))':
+  '@nuxt/test-utils@3.13.1(h3@1.15.4)(magicast@0.5.1)(nitropack@2.12.9(encoding@0.1.13))(vite@6.4.1(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2))(vitest@3.2.4(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2))(vue-router@4.6.4(vue@3.4.31(typescript@5.5.4)))(vue@3.4.31(typescript@5.5.4))':
     dependencies:
       '@nuxt/kit': 3.15.4(magicast@0.5.1)
       '@nuxt/schema': 3.15.4
@@ -10194,7 +10396,7 @@ snapshots:
       fake-indexeddb: 5.0.2
       get-port-please: 3.1.2
       h3: 1.15.4
-      local-pkg: 0.5.0
+      local-pkg: 0.5.1
       magic-string: 0.30.11
       nitropack: 2.12.9(encoding@0.1.13)
       node-fetch-native: 1.6.4
@@ -10207,22 +10409,22 @@ snapshots:
       ufo: 1.5.4
       unenv: 1.10.0
       unplugin: 1.12.1
-      vite: 6.4.1(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2)
-      vitest-environment-nuxt: 1.0.0(h3@1.15.4)(magicast@0.5.1)(nitropack@2.12.9(encoding@0.1.13))(vite@6.4.1(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2))(vitest@3.2.4(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2))(vue-router@4.6.4(vue@3.4.31(typescript@5.5.4)))(vue@3.4.31(typescript@5.5.4))
+      vite: 6.4.1(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2)
+      vitest-environment-nuxt: 1.0.0(h3@1.15.4)(magicast@0.5.1)(nitropack@2.12.9(encoding@0.1.13))(vite@6.4.1(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2))(vitest@3.2.4(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2))(vue-router@4.6.4(vue@3.4.31(typescript@5.5.4)))(vue@3.4.31(typescript@5.5.4))
       vue: 3.4.31(typescript@5.5.4)
       vue-router: 4.6.4(vue@3.4.31(typescript@5.5.4))
     optionalDependencies:
-      vitest: 3.2.4(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2)
+      vitest: 3.2.4(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2)
     transitivePeerDependencies:
       - magicast
       - supports-color
 
-  '@nuxt/vite-builder@3.15.4(@types/node@18.0.0)(eslint@8.54.0)(magicast@0.5.1)(optionator@0.9.3)(rollup@4.53.4)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(typescript@5.5.4)(vue-tsc@2.1.10(typescript@5.5.4))(vue@3.4.31(typescript@5.5.4))(yaml@2.8.2)':
+  '@nuxt/vite-builder@3.15.4(@types/node@18.0.0)(eslint@8.54.0)(magicast@0.5.1)(optionator@0.9.3)(rollup@4.53.4)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(typescript@5.5.4)(vue-tsc@2.1.10(typescript@5.5.4))(vue@3.4.31(typescript@5.5.4))(yaml@2.8.2)':
     dependencies:
       '@nuxt/kit': 3.15.4(magicast@0.5.1)
       '@rollup/plugin-replace': 6.0.3(rollup@4.53.4)
-      '@vitejs/plugin-vue': 5.2.4(vite@6.4.1(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2))(vue@3.4.31(typescript@5.5.4))
-      '@vitejs/plugin-vue-jsx': 4.2.0(vite@6.4.1(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2))(vue@3.4.31(typescript@5.5.4))
+      '@vitejs/plugin-vue': 5.2.4(vite@6.4.1(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2))(vue@3.4.31(typescript@5.5.4))
+      '@vitejs/plugin-vue-jsx': 4.2.0(vite@6.4.1(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2))(vue@3.4.31(typescript@5.5.4))
       autoprefixer: 10.4.23(postcss@8.5.6)
       consola: 3.4.2
       cssnano: 7.1.2(postcss@8.5.6)
@@ -10246,9 +10448,9 @@ snapshots:
       ufo: 1.6.1
       unenv: 1.10.0
       unplugin: 2.3.11
-      vite: 6.4.1(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2)
-      vite-node: 3.2.4(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2)
-      vite-plugin-checker: 0.8.0(eslint@8.54.0)(optionator@0.9.3)(typescript@5.5.4)(vite@6.4.1(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2))(vue-tsc@2.1.10(typescript@5.5.4))
+      vite: 6.4.1(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2)
+      vite-node: 3.2.4(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2)
+      vite-plugin-checker: 0.8.0(eslint@8.54.0)(optionator@0.9.3)(typescript@5.5.4)(vite@6.4.1(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2))(vue-tsc@2.1.10(typescript@5.5.4))
       vue: 3.4.31(typescript@5.5.4)
       vue-bundle-renderer: 2.2.0
     transitivePeerDependencies:
@@ -10276,12 +10478,12 @@ snapshots:
       - vue-tsc
       - yaml
 
-  '@nuxt/vite-builder@3.15.4(@types/node@25.0.2)(eslint@8.54.0)(magicast@0.3.5)(optionator@0.9.3)(rollup@4.53.4)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(typescript@5.5.4)(vue-tsc@2.1.10(typescript@5.5.4))(vue@3.4.31(typescript@5.5.4))(yaml@2.8.2)':
+  '@nuxt/vite-builder@3.15.4(@types/node@25.0.2)(eslint@8.54.0)(magicast@0.3.5)(optionator@0.9.3)(rollup@4.53.4)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(typescript@5.5.4)(vue-tsc@2.1.10(typescript@5.5.4))(vue@3.4.31(typescript@5.5.4))(yaml@2.8.2)':
     dependencies:
       '@nuxt/kit': 3.15.4(magicast@0.3.5)
       '@rollup/plugin-replace': 6.0.3(rollup@4.53.4)
-      '@vitejs/plugin-vue': 5.2.4(vite@6.4.1(@types/node@25.0.2)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2))(vue@3.4.31(typescript@5.5.4))
-      '@vitejs/plugin-vue-jsx': 4.2.0(vite@6.4.1(@types/node@25.0.2)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2))(vue@3.4.31(typescript@5.5.4))
+      '@vitejs/plugin-vue': 5.2.4(vite@6.4.1(@types/node@25.0.2)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2))(vue@3.4.31(typescript@5.5.4))
+      '@vitejs/plugin-vue-jsx': 4.2.0(vite@6.4.1(@types/node@25.0.2)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2))(vue@3.4.31(typescript@5.5.4))
       autoprefixer: 10.4.23(postcss@8.5.6)
       consola: 3.4.2
       cssnano: 7.1.2(postcss@8.5.6)
@@ -10305,9 +10507,9 @@ snapshots:
       ufo: 1.6.1
       unenv: 1.10.0
       unplugin: 2.3.11
-      vite: 6.4.1(@types/node@25.0.2)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2)
-      vite-node: 3.2.4(@types/node@25.0.2)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2)
-      vite-plugin-checker: 0.8.0(eslint@8.54.0)(optionator@0.9.3)(typescript@5.5.4)(vite@6.4.1(@types/node@25.0.2)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2))(vue-tsc@2.1.10(typescript@5.5.4))
+      vite: 6.4.1(@types/node@25.0.2)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2)
+      vite-node: 3.2.4(@types/node@25.0.2)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2)
+      vite-plugin-checker: 0.8.0(eslint@8.54.0)(optionator@0.9.3)(typescript@5.5.4)(vite@6.4.1(@types/node@25.0.2)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2))(vue-tsc@2.1.10(typescript@5.5.4))
       vue: 3.4.31(typescript@5.5.4)
       vue-bundle-renderer: 2.2.0
     transitivePeerDependencies:
@@ -10547,10 +10749,10 @@ snapshots:
     optionalDependencies:
       rollup: 4.53.4
 
-  '@rollup/plugin-babel@5.3.1(@babel/core@7.28.5)(rollup@2.79.2)':
+  '@rollup/plugin-babel@5.3.1(@babel/core@7.28.6)(rollup@2.79.2)':
     dependencies:
-      '@babel/core': 7.28.5
-      '@babel/helper-module-imports': 7.27.1
+      '@babel/core': 7.28.6
+      '@babel/helper-module-imports': 7.28.6
       '@rollup/pluginutils': 3.1.0(rollup@2.79.2)
       rollup: 2.79.2
     transitivePeerDependencies:
@@ -10845,11 +11047,15 @@ snapshots:
 
   '@types/node@18.0.0': {}
 
+  '@types/node@18.19.130':
+    dependencies:
+      undici-types: 5.26.5
+
   '@types/node@20.17.4':
     dependencies:
       undici-types: 6.19.8
 
-  '@types/node@20.19.27':
+  '@types/node@20.19.30':
     dependencies:
       undici-types: 6.21.0
 
@@ -10868,7 +11074,7 @@ snapshots:
 
   '@types/resolve@1.17.1':
     dependencies:
-      '@types/node': 20.19.27
+      '@types/node': 20.19.30
 
   '@types/resolve@1.20.2': {}
 
@@ -10933,7 +11139,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/typescript-estree': 6.10.0(typescript@5.5.4)
       '@typescript-eslint/utils': 6.10.0(eslint@8.54.0)(typescript@5.5.4)
-      debug: 4.4.3
+      debug: 4.3.6
       eslint: 8.54.0
       ts-api-utils: 1.0.1(typescript@5.5.4)
     optionalDependencies:
@@ -11042,43 +11248,43 @@ snapshots:
       unhead: 1.11.20
       vue: 3.4.31(typescript@5.5.4)
 
-  '@unocss/astro@0.62.1(rollup@2.79.2)(vite@6.4.1(@types/node@20.6.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2))':
+  '@unocss/astro@0.62.1(rollup@2.79.2)(vite@6.4.1(@types/node@20.6.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2))':
     dependencies:
       '@unocss/core': 0.62.1
       '@unocss/reset': 0.62.1
-      '@unocss/vite': 0.62.1(rollup@2.79.2)(vite@6.4.1(@types/node@20.6.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2))
+      '@unocss/vite': 0.62.1(rollup@2.79.2)(vite@6.4.1(@types/node@20.6.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2))
     optionalDependencies:
-      vite: 6.4.1(@types/node@20.6.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2)
+      vite: 6.4.1(@types/node@20.6.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2)
     transitivePeerDependencies:
       - rollup
       - supports-color
 
-  '@unocss/astro@0.62.4(rollup@4.53.4)(vite@6.4.1(@types/node@25.0.2)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2))':
+  '@unocss/astro@0.62.4(rollup@4.53.4)(vite@6.4.1(@types/node@25.0.2)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2))':
     dependencies:
       '@unocss/core': 0.62.4
       '@unocss/reset': 0.62.4
-      '@unocss/vite': 0.62.4(rollup@4.53.4)(vite@6.4.1(@types/node@25.0.2)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2))
+      '@unocss/vite': 0.62.4(rollup@4.53.4)(vite@6.4.1(@types/node@25.0.2)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2))
     optionalDependencies:
-      vite: 6.4.1(@types/node@25.0.2)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2)
+      vite: 6.4.1(@types/node@25.0.2)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2)
     transitivePeerDependencies:
       - rollup
       - supports-color
 
-  '@unocss/astro@66.5.10(vite@6.4.1(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2))':
+  '@unocss/astro@66.5.10(vite@6.4.1(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2))':
     dependencies:
       '@unocss/core': 66.5.10
       '@unocss/reset': 66.5.10
-      '@unocss/vite': 66.5.10(vite@6.4.1(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2))
+      '@unocss/vite': 66.5.10(vite@6.4.1(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2))
     optionalDependencies:
-      vite: 6.4.1(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2)
+      vite: 6.4.1(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2)
 
-  '@unocss/astro@66.5.10(vite@6.4.1(@types/node@25.0.2)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2))':
+  '@unocss/astro@66.5.10(vite@6.4.1(@types/node@25.0.2)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2))':
     dependencies:
       '@unocss/core': 66.5.10
       '@unocss/reset': 66.5.10
-      '@unocss/vite': 66.5.10(vite@6.4.1(@types/node@25.0.2)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2))
+      '@unocss/vite': 66.5.10(vite@6.4.1(@types/node@25.0.2)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2))
     optionalDependencies:
-      vite: 6.4.1(@types/node@25.0.2)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2)
+      vite: 6.4.1(@types/node@25.0.2)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2)
 
   '@unocss/cli@0.62.1(rollup@2.79.2)':
     dependencies:
@@ -11194,7 +11400,7 @@ snapshots:
       sirv: 3.0.2
       vue-flow-layout: 0.2.0
 
-  '@unocss/nuxt@0.62.4(magicast@0.3.5)(postcss@8.5.6)(rollup@4.53.4)(vite@6.4.1(@types/node@25.0.2)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2))(webpack@5.88.2(esbuild@0.23.0))':
+  '@unocss/nuxt@0.62.4(magicast@0.3.5)(postcss@8.5.6)(rollup@4.53.4)(vite@6.4.1(@types/node@25.0.2)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2))(webpack@5.88.2(esbuild@0.23.0))':
     dependencies:
       '@nuxt/kit': 3.15.4(magicast@0.3.5)
       '@unocss/config': 0.62.4
@@ -11207,9 +11413,9 @@ snapshots:
       '@unocss/preset-web-fonts': 0.62.4
       '@unocss/preset-wind': 0.62.4
       '@unocss/reset': 0.62.4
-      '@unocss/vite': 0.62.4(rollup@4.53.4)(vite@6.4.1(@types/node@25.0.2)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2))
+      '@unocss/vite': 0.62.4(rollup@4.53.4)(vite@6.4.1(@types/node@25.0.2)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2))
       '@unocss/webpack': 0.62.4(rollup@4.53.4)(webpack@5.88.2(esbuild@0.23.0))
-      unocss: 0.62.4(@unocss/webpack@0.62.4(rollup@4.53.4)(webpack@5.88.2(esbuild@0.23.0)))(postcss@8.5.6)(rollup@4.53.4)(vite@6.4.1(@types/node@25.0.2)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2))
+      unocss: 0.62.4(@unocss/webpack@0.62.4(rollup@4.53.4)(webpack@5.88.2(esbuild@0.23.0)))(postcss@8.5.6)(rollup@4.53.4)(vite@6.4.1(@types/node@25.0.2)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2))
     transitivePeerDependencies:
       - magicast
       - postcss
@@ -11218,7 +11424,7 @@ snapshots:
       - vite
       - webpack
 
-  '@unocss/nuxt@66.5.10(magicast@0.3.5)(postcss@8.5.6)(vite@6.4.1(@types/node@25.0.2)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2))(webpack@5.88.2(esbuild@0.23.0))':
+  '@unocss/nuxt@66.5.10(magicast@0.3.5)(postcss@8.5.6)(vite@6.4.1(@types/node@25.0.2)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2))(webpack@5.88.2(esbuild@0.25.12))':
     dependencies:
       '@nuxt/kit': 3.15.4(magicast@0.3.5)
       '@unocss/config': 66.5.10
@@ -11231,9 +11437,9 @@ snapshots:
       '@unocss/preset-wind3': 66.5.10
       '@unocss/preset-wind4': 66.5.10
       '@unocss/reset': 66.5.10
-      '@unocss/vite': 66.5.10(vite@6.4.1(@types/node@25.0.2)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2))
-      '@unocss/webpack': 66.5.10(webpack@5.88.2(esbuild@0.23.0))
-      unocss: 66.5.10(@unocss/webpack@66.5.10(webpack@5.88.2(esbuild@0.23.0)))(postcss@8.5.6)(vite@6.4.1(@types/node@25.0.2)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2))
+      '@unocss/vite': 66.5.10(vite@6.4.1(@types/node@25.0.2)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2))
+      '@unocss/webpack': 66.5.10(webpack@5.88.2(esbuild@0.25.12))
+      unocss: 66.5.10(@unocss/webpack@66.5.10(webpack@5.88.2(esbuild@0.25.12)))(postcss@8.5.6)(vite@6.4.1(@types/node@25.0.2)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2))
     transitivePeerDependencies:
       - magicast
       - postcss
@@ -11241,7 +11447,7 @@ snapshots:
       - vite
       - webpack
 
-  '@unocss/nuxt@66.5.10(magicast@0.5.1)(postcss@8.5.6)(vite@6.4.1(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2))(webpack@5.88.2(esbuild@0.23.0))':
+  '@unocss/nuxt@66.5.10(magicast@0.5.1)(postcss@8.5.6)(vite@6.4.1(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2))(webpack@5.88.2(esbuild@0.25.12))':
     dependencies:
       '@nuxt/kit': 3.15.4(magicast@0.5.1)
       '@unocss/config': 66.5.10
@@ -11254,9 +11460,9 @@ snapshots:
       '@unocss/preset-wind3': 66.5.10
       '@unocss/preset-wind4': 66.5.10
       '@unocss/reset': 66.5.10
-      '@unocss/vite': 66.5.10(vite@6.4.1(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2))
-      '@unocss/webpack': 66.5.10(webpack@5.88.2(esbuild@0.23.0))
-      unocss: 66.5.10(@unocss/webpack@66.5.10(webpack@5.88.2(esbuild@0.23.0)))(postcss@8.5.6)(vite@6.4.1(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2))
+      '@unocss/vite': 66.5.10(vite@6.4.1(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2))
+      '@unocss/webpack': 66.5.10(webpack@5.88.2(esbuild@0.25.12))
+      unocss: 66.5.10(@unocss/webpack@66.5.10(webpack@5.88.2(esbuild@0.25.12)))(postcss@8.5.6)(vite@6.4.1(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2))
     transitivePeerDependencies:
       - magicast
       - postcss
@@ -11528,7 +11734,7 @@ snapshots:
     dependencies:
       '@unocss/core': 66.5.10
 
-  '@unocss/vite@0.62.1(rollup@2.79.2)(vite@6.4.1(@types/node@20.6.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2))':
+  '@unocss/vite@0.62.1(rollup@2.79.2)(vite@6.4.1(@types/node@20.6.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@rollup/pluginutils': 5.1.0(rollup@2.79.2)
@@ -11540,12 +11746,12 @@ snapshots:
       chokidar: 3.6.0
       magic-string: 0.30.21
       tinyglobby: 0.2.15
-      vite: 6.4.1(@types/node@20.6.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2)
+      vite: 6.4.1(@types/node@20.6.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2)
     transitivePeerDependencies:
       - rollup
       - supports-color
 
-  '@unocss/vite@0.62.4(rollup@4.53.4)(vite@6.4.1(@types/node@25.0.2)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2))':
+  '@unocss/vite@0.62.4(rollup@4.53.4)(vite@6.4.1(@types/node@25.0.2)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@rollup/pluginutils': 5.3.0(rollup@4.53.4)
@@ -11555,12 +11761,12 @@ snapshots:
       chokidar: 3.6.0
       magic-string: 0.30.21
       tinyglobby: 0.2.15
-      vite: 6.4.1(@types/node@25.0.2)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2)
+      vite: 6.4.1(@types/node@25.0.2)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2)
     transitivePeerDependencies:
       - rollup
       - supports-color
 
-  '@unocss/vite@66.5.10(vite@6.4.1(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2))':
+  '@unocss/vite@66.5.10(vite@6.4.1(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2))':
     dependencies:
       '@jridgewell/remapping': 2.3.5
       '@unocss/config': 66.5.10
@@ -11571,9 +11777,9 @@ snapshots:
       pathe: 2.0.3
       tinyglobby: 0.2.15
       unplugin-utils: 0.3.1
-      vite: 6.4.1(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2)
+      vite: 6.4.1(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2)
 
-  '@unocss/vite@66.5.10(vite@6.4.1(@types/node@25.0.2)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2))':
+  '@unocss/vite@66.5.10(vite@6.4.1(@types/node@25.0.2)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2))':
     dependencies:
       '@jridgewell/remapping': 2.3.5
       '@unocss/config': 66.5.10
@@ -11584,9 +11790,9 @@ snapshots:
       pathe: 2.0.3
       tinyglobby: 0.2.15
       unplugin-utils: 0.3.1
-      vite: 6.4.1(@types/node@25.0.2)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2)
+      vite: 6.4.1(@types/node@25.0.2)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2)
 
-  '@unocss/webpack@0.62.1(rollup@2.79.2)(webpack@5.88.2(esbuild@0.23.0))':
+  '@unocss/webpack@0.62.1(rollup@2.79.2)(webpack@5.88.2(esbuild@0.25.12))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@rollup/pluginutils': 5.3.0(rollup@2.79.2)
@@ -11596,7 +11802,7 @@ snapshots:
       magic-string: 0.30.21
       tinyglobby: 0.2.15
       unplugin: 1.16.1
-      webpack: 5.88.2(esbuild@0.23.0)
+      webpack: 5.88.2(esbuild@0.25.12)
       webpack-sources: 3.3.3
     transitivePeerDependencies:
       - rollup
@@ -11619,7 +11825,7 @@ snapshots:
       - rollup
       - supports-color
 
-  '@unocss/webpack@66.5.10(webpack@5.88.2(esbuild@0.23.0))':
+  '@unocss/webpack@66.5.10(webpack@5.88.2(esbuild@0.25.12))':
     dependencies:
       '@jridgewell/remapping': 2.3.5
       '@unocss/config': 66.5.10
@@ -11630,7 +11836,7 @@ snapshots:
       tinyglobby: 0.2.15
       unplugin: 2.3.11
       unplugin-utils: 0.3.1
-      webpack: 5.88.2(esbuild@0.23.0)
+      webpack: 5.88.2(esbuild@0.25.12)
       webpack-sources: 3.3.3
 
   '@vercel/nft@0.30.4(encoding@0.1.13)(rollup@4.53.4)':
@@ -11661,47 +11867,47 @@ snapshots:
       sharp-ico: 0.1.5
       unconfig: 0.3.13
 
-  '@vite-pwa/vitepress@0.5.0(@vite-pwa/assets-generator@0.2.4)(vite-plugin-pwa@0.20.1(@vite-pwa/assets-generator@0.2.4)(vite@6.4.1(@types/node@20.6.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2))(workbox-build@7.0.0)(workbox-window@7.1.0))':
+  '@vite-pwa/vitepress@0.5.0(@vite-pwa/assets-generator@0.2.4)(vite-plugin-pwa@0.20.1(@vite-pwa/assets-generator@0.2.4)(vite@6.4.1(@types/node@20.6.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2))(workbox-build@7.0.0)(workbox-window@7.1.0))':
     dependencies:
-      vite-plugin-pwa: 0.20.1(@vite-pwa/assets-generator@0.2.4)(vite@6.4.1(@types/node@20.6.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2))(workbox-build@7.0.0)(workbox-window@7.1.0)
+      vite-plugin-pwa: 0.20.1(@vite-pwa/assets-generator@0.2.4)(vite@6.4.1(@types/node@20.6.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2))(workbox-build@7.0.0)(workbox-window@7.1.0)
     optionalDependencies:
       '@vite-pwa/assets-generator': 0.2.4
 
-  '@vitejs/plugin-vue-jsx@4.2.0(vite@6.4.1(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2))(vue@3.4.31(typescript@5.5.4))':
+  '@vitejs/plugin-vue-jsx@4.2.0(vite@6.4.1(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2))(vue@3.4.31(typescript@5.5.4))':
     dependencies:
       '@babel/core': 7.28.5
       '@babel/plugin-transform-typescript': 7.28.5(@babel/core@7.28.5)
       '@rolldown/pluginutils': 1.0.0-beta.54
       '@vue/babel-plugin-jsx': 1.5.0(@babel/core@7.28.5)
-      vite: 6.4.1(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2)
+      vite: 6.4.1(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2)
       vue: 3.4.31(typescript@5.5.4)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitejs/plugin-vue-jsx@4.2.0(vite@6.4.1(@types/node@25.0.2)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2))(vue@3.4.31(typescript@5.5.4))':
+  '@vitejs/plugin-vue-jsx@4.2.0(vite@6.4.1(@types/node@25.0.2)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2))(vue@3.4.31(typescript@5.5.4))':
     dependencies:
       '@babel/core': 7.28.5
       '@babel/plugin-transform-typescript': 7.28.5(@babel/core@7.28.5)
       '@rolldown/pluginutils': 1.0.0-beta.54
       '@vue/babel-plugin-jsx': 1.5.0(@babel/core@7.28.5)
-      vite: 6.4.1(@types/node@25.0.2)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2)
+      vite: 6.4.1(@types/node@25.0.2)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2)
       vue: 3.4.31(typescript@5.5.4)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitejs/plugin-vue@5.0.5(vite@6.4.1(@types/node@20.6.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2))(vue@3.4.31(typescript@5.5.4))':
+  '@vitejs/plugin-vue@5.0.5(vite@6.4.1(@types/node@20.6.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2))(vue@3.4.31(typescript@5.5.4))':
     dependencies:
-      vite: 6.4.1(@types/node@20.6.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2)
+      vite: 6.4.1(@types/node@20.6.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2)
       vue: 3.4.31(typescript@5.5.4)
 
-  '@vitejs/plugin-vue@5.2.4(vite@6.4.1(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2))(vue@3.4.31(typescript@5.5.4))':
+  '@vitejs/plugin-vue@5.2.4(vite@6.4.1(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2))(vue@3.4.31(typescript@5.5.4))':
     dependencies:
-      vite: 6.4.1(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2)
+      vite: 6.4.1(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2)
       vue: 3.4.31(typescript@5.5.4)
 
-  '@vitejs/plugin-vue@5.2.4(vite@6.4.1(@types/node@25.0.2)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2))(vue@3.4.31(typescript@5.5.4))':
+  '@vitejs/plugin-vue@5.2.4(vite@6.4.1(@types/node@25.0.2)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2))(vue@3.4.31(typescript@5.5.4))':
     dependencies:
-      vite: 6.4.1(@types/node@25.0.2)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2)
+      vite: 6.4.1(@types/node@25.0.2)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2)
       vue: 3.4.31(typescript@5.5.4)
 
   '@vitest/expect@3.2.4':
@@ -11712,13 +11918,13 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.4(vite@6.4.1(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2))':
+  '@vitest/mocker@3.2.4(vite@6.4.1(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 6.4.1(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2)
+      vite: 6.4.1(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -11871,50 +12077,50 @@ snapshots:
     dependencies:
       '@vue/devtools-kit': 7.3.8
 
-  '@vue/devtools-core@7.6.8(vite@6.4.1(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2))(vue@3.4.31(typescript@5.5.4))':
+  '@vue/devtools-core@7.6.8(vite@6.4.1(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2))(vue@3.4.31(typescript@5.5.4))':
     dependencies:
       '@vue/devtools-kit': 7.6.8
       '@vue/devtools-shared': 7.7.9
       mitt: 3.0.1
       nanoid: 5.1.6
       pathe: 1.1.2
-      vite-hot-client: 0.2.4(vite@6.4.1(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2))
+      vite-hot-client: 0.2.4(vite@6.4.1(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2))
       vue: 3.4.31(typescript@5.5.4)
     transitivePeerDependencies:
       - vite
 
-  '@vue/devtools-core@7.6.8(vite@6.4.1(@types/node@25.0.2)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2))(vue@3.4.31(typescript@5.5.4))':
+  '@vue/devtools-core@7.6.8(vite@6.4.1(@types/node@25.0.2)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2))(vue@3.4.31(typescript@5.5.4))':
     dependencies:
       '@vue/devtools-kit': 7.6.8
       '@vue/devtools-shared': 7.7.9
       mitt: 3.0.1
       nanoid: 5.1.6
       pathe: 1.1.2
-      vite-hot-client: 0.2.4(vite@6.4.1(@types/node@25.0.2)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2))
+      vite-hot-client: 0.2.4(vite@6.4.1(@types/node@25.0.2)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2))
       vue: 3.4.31(typescript@5.5.4)
     transitivePeerDependencies:
       - vite
 
-  '@vue/devtools-core@8.0.5(vite@6.4.1(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2))(vue@3.4.31(typescript@5.5.4))':
+  '@vue/devtools-core@8.0.5(vite@6.4.1(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2))(vue@3.4.31(typescript@5.5.4))':
     dependencies:
       '@vue/devtools-kit': 8.0.5
       '@vue/devtools-shared': 8.0.5
       mitt: 3.0.1
       nanoid: 5.1.6
       pathe: 2.0.3
-      vite-hot-client: 2.1.0(vite@6.4.1(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2))
+      vite-hot-client: 2.1.0(vite@6.4.1(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2))
       vue: 3.4.31(typescript@5.5.4)
     transitivePeerDependencies:
       - vite
 
-  '@vue/devtools-core@8.0.5(vite@6.4.1(@types/node@25.0.2)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2))(vue@3.4.31(typescript@5.5.4))':
+  '@vue/devtools-core@8.0.5(vite@6.4.1(@types/node@25.0.2)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2))(vue@3.4.31(typescript@5.5.4))':
     dependencies:
       '@vue/devtools-kit': 8.0.5
       '@vue/devtools-shared': 8.0.5
       mitt: 3.0.1
       nanoid: 5.1.6
       pathe: 2.0.3
-      vite-hot-client: 2.1.0(vite@6.4.1(@types/node@25.0.2)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2))
+      vite-hot-client: 2.1.0(vite@6.4.1(@types/node@25.0.2)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2))
       vue: 3.4.31(typescript@5.5.4)
     transitivePeerDependencies:
       - vite
@@ -12002,11 +12208,11 @@ snapshots:
 
   '@vue/shared@3.5.25': {}
 
-  '@vuetify/loader-shared@2.1.1(vue@3.4.31(typescript@5.5.4))(vuetify@3.7.0)':
+  '@vuetify/loader-shared@2.1.2(vue@3.4.31(typescript@5.5.4))(vuetify@3.7.0)':
     dependencies:
       upath: 2.0.1
       vue: 3.4.31(typescript@5.5.4)
-      vuetify: 3.7.0(typescript@5.5.4)(vite-plugin-vuetify@2.1.2)(vue-i18n@9.10.2(vue@3.4.31(typescript@5.5.4)))(vue@3.4.31(typescript@5.5.4))
+      vuetify: 3.7.0(typescript@5.5.4)(vite-plugin-vuetify@2.1.3)(vue-i18n@9.10.2(vue@3.4.31(typescript@5.5.4)))(vue@3.4.31(typescript@5.5.4))
 
   '@vueuse/core@10.11.1(vue@3.4.31(typescript@5.5.4))':
     dependencies:
@@ -12300,27 +12506,27 @@ snapshots:
 
   b4a@1.7.3: {}
 
-  babel-plugin-polyfill-corejs2@0.4.14(@babel/core@7.28.5):
+  babel-plugin-polyfill-corejs2@0.4.14(@babel/core@7.28.6):
     dependencies:
-      '@babel/compat-data': 7.28.5
-      '@babel/core': 7.28.5
-      '@babel/helper-define-polyfill-provider': 0.6.5(@babel/core@7.28.5)
+      '@babel/compat-data': 7.28.6
+      '@babel/core': 7.28.6
+      '@babel/helper-define-polyfill-provider': 0.6.5(@babel/core@7.28.6)
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
 
-  babel-plugin-polyfill-corejs3@0.13.0(@babel/core@7.28.5):
+  babel-plugin-polyfill-corejs3@0.13.0(@babel/core@7.28.6):
     dependencies:
-      '@babel/core': 7.28.5
-      '@babel/helper-define-polyfill-provider': 0.6.5(@babel/core@7.28.5)
+      '@babel/core': 7.28.6
+      '@babel/helper-define-polyfill-provider': 0.6.5(@babel/core@7.28.6)
       core-js-compat: 3.47.0
     transitivePeerDependencies:
       - supports-color
 
-  babel-plugin-polyfill-regenerator@0.6.5(@babel/core@7.28.5):
+  babel-plugin-polyfill-regenerator@0.6.5(@babel/core@7.28.6):
     dependencies:
-      '@babel/core': 7.28.5
-      '@babel/helper-define-polyfill-provider': 0.6.5(@babel/core@7.28.5)
+      '@babel/core': 7.28.6
+      '@babel/helper-define-polyfill-provider': 0.6.5(@babel/core@7.28.6)
     transitivePeerDependencies:
       - supports-color
 
@@ -12435,7 +12641,7 @@ snapshots:
       defu: 6.1.4
       dotenv: 16.4.5
       giget: 1.2.3
-      jiti: 1.21.6
+      jiti: 1.21.7
       mlly: 1.7.1
       ohash: 1.1.3
       pathe: 1.1.2
@@ -13083,7 +13289,7 @@ snapshots:
       typed-array-byte-offset: 1.0.4
       typed-array-length: 1.0.7
       unbox-primitive: 1.1.0
-      which-typed-array: 1.1.19
+      which-typed-array: 1.1.20
 
   es-define-property@1.0.1: {}
 
@@ -14218,7 +14424,7 @@ snapshots:
 
   is-typed-array@1.1.15:
     dependencies:
-      which-typed-array: 1.1.19
+      which-typed-array: 1.1.20
 
   is-weakmap@2.0.2: {}
 
@@ -14283,17 +14489,15 @@ snapshots:
 
   jest-worker@26.6.2:
     dependencies:
-      '@types/node': 20.19.27
+      '@types/node': 20.19.30
       merge-stream: 2.0.0
       supports-color: 7.2.0
 
   jest-worker@27.5.1:
     dependencies:
-      '@types/node': 20.19.27
+      '@types/node': 18.19.130
       merge-stream: 2.0.0
       supports-color: 8.1.1
-
-  jiti@1.21.6: {}
 
   jiti@1.21.7: {}
 
@@ -14404,11 +14608,6 @@ snapshots:
   loader-runner@4.3.1: {}
 
   local-pkg@0.4.3: {}
-
-  local-pkg@0.5.0:
-    dependencies:
-      mlly: 1.7.1
-      pkg-types: 1.1.3
 
   local-pkg@0.5.1:
     dependencies:
@@ -14605,7 +14804,7 @@ snapshots:
 
   mkdirp@1.0.4: {}
 
-  mkdist@2.4.1(sass@1.77.8)(typescript@5.5.4)(vue-sfc-transformer@0.1.17(@vue/compiler-core@3.5.25)(esbuild@0.23.0)(vue@3.4.31(typescript@5.5.4)))(vue-tsc@2.1.10(typescript@5.5.4))(vue@3.4.31(typescript@5.5.4)):
+  mkdist@2.4.1(sass@1.77.8)(typescript@5.5.4)(vue-sfc-transformer@0.1.17(@vue/compiler-core@3.5.25)(esbuild@0.25.12)(vue@3.4.31(typescript@5.5.4)))(vue-tsc@2.1.10(typescript@5.5.4))(vue@3.4.31(typescript@5.5.4)):
     dependencies:
       autoprefixer: 10.4.23(postcss@8.5.6)
       citty: 0.1.6
@@ -14624,7 +14823,7 @@ snapshots:
       sass: 1.77.8
       typescript: 5.5.4
       vue: 3.4.31(typescript@5.5.4)
-      vue-sfc-transformer: 0.1.17(@vue/compiler-core@3.5.25)(esbuild@0.23.0)(vue@3.4.31(typescript@5.5.4))
+      vue-sfc-transformer: 0.1.17(@vue/compiler-core@3.5.25)(esbuild@0.25.12)(vue@3.4.31(typescript@5.5.4))
       vue-tsc: 2.1.10(typescript@5.5.4)
 
   mlly@1.7.1:
@@ -14860,15 +15059,15 @@ snapshots:
     dependencies:
       boolbase: 1.0.0
 
-  nuxt@3.15.4(@parcel/watcher@2.4.1)(@types/node@18.0.0)(cac@6.7.14)(db0@0.3.4)(encoding@0.1.13)(eslint@8.54.0)(ioredis@5.8.2)(magicast@0.5.1)(optionator@0.9.3)(rollup@4.53.4)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(typescript@5.5.4)(vite@6.4.1(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2))(vue-tsc@2.1.10(typescript@5.5.4))(yaml@2.8.2):
+  nuxt@3.15.4(@parcel/watcher@2.4.1)(@types/node@18.0.0)(cac@6.7.14)(db0@0.3.4)(encoding@0.1.13)(eslint@8.54.0)(ioredis@5.8.2)(magicast@0.5.1)(optionator@0.9.3)(rollup@4.53.4)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(typescript@5.5.4)(vite@6.4.1(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2))(vue-tsc@2.1.10(typescript@5.5.4))(yaml@2.8.2):
     dependencies:
       '@nuxt/cli': 3.31.2(cac@6.7.14)(magicast@0.5.1)
       '@nuxt/devalue': 2.0.2
-      '@nuxt/devtools': 1.7.0(rollup@4.53.4)(vite@6.4.1(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2))(vue@3.4.31(typescript@5.5.4))
+      '@nuxt/devtools': 1.7.0(rollup@4.53.4)(vite@6.4.1(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2))(vue@3.4.31(typescript@5.5.4))
       '@nuxt/kit': 3.15.4(magicast@0.5.1)
       '@nuxt/schema': 3.15.4
       '@nuxt/telemetry': 2.6.6(magicast@0.5.1)
-      '@nuxt/vite-builder': 3.15.4(@types/node@18.0.0)(eslint@8.54.0)(magicast@0.5.1)(optionator@0.9.3)(rollup@4.53.4)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(typescript@5.5.4)(vue-tsc@2.1.10(typescript@5.5.4))(vue@3.4.31(typescript@5.5.4))(yaml@2.8.2)
+      '@nuxt/vite-builder': 3.15.4(@types/node@18.0.0)(eslint@8.54.0)(magicast@0.5.1)(optionator@0.9.3)(rollup@4.53.4)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(typescript@5.5.4)(vue-tsc@2.1.10(typescript@5.5.4))(vue@3.4.31(typescript@5.5.4))(yaml@2.8.2)
       '@unhead/dom': 1.11.20
       '@unhead/shared': 1.11.20
       '@unhead/ssr': 1.11.20
@@ -14987,15 +15186,15 @@ snapshots:
       - xml2js
       - yaml
 
-  nuxt@3.15.4(@parcel/watcher@2.5.1)(@types/node@25.0.2)(cac@6.7.14)(db0@0.3.4)(encoding@0.1.13)(eslint@8.54.0)(ioredis@5.8.2)(magicast@0.3.5)(optionator@0.9.3)(rollup@4.53.4)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(typescript@5.5.4)(vite@6.4.1(@types/node@25.0.2)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2))(vue-tsc@2.1.10(typescript@5.5.4))(yaml@2.8.2):
+  nuxt@3.15.4(@parcel/watcher@2.5.1)(@types/node@25.0.2)(cac@6.7.14)(db0@0.3.4)(encoding@0.1.13)(eslint@8.54.0)(ioredis@5.8.2)(magicast@0.3.5)(optionator@0.9.3)(rollup@4.53.4)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(typescript@5.5.4)(vite@6.4.1(@types/node@25.0.2)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2))(vue-tsc@2.1.10(typescript@5.5.4))(yaml@2.8.2):
     dependencies:
       '@nuxt/cli': 3.31.2(cac@6.7.14)(magicast@0.3.5)
       '@nuxt/devalue': 2.0.2
-      '@nuxt/devtools': 1.7.0(rollup@4.53.4)(vite@6.4.1(@types/node@25.0.2)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2))(vue@3.4.31(typescript@5.5.4))
+      '@nuxt/devtools': 1.7.0(rollup@4.53.4)(vite@6.4.1(@types/node@25.0.2)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2))(vue@3.4.31(typescript@5.5.4))
       '@nuxt/kit': 3.15.4(magicast@0.3.5)
       '@nuxt/schema': 3.15.4
       '@nuxt/telemetry': 2.6.6(magicast@0.3.5)
-      '@nuxt/vite-builder': 3.15.4(@types/node@25.0.2)(eslint@8.54.0)(magicast@0.3.5)(optionator@0.9.3)(rollup@4.53.4)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(typescript@5.5.4)(vue-tsc@2.1.10(typescript@5.5.4))(vue@3.4.31(typescript@5.5.4))(yaml@2.8.2)
+      '@nuxt/vite-builder': 3.15.4(@types/node@25.0.2)(eslint@8.54.0)(magicast@0.3.5)(optionator@0.9.3)(rollup@4.53.4)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(typescript@5.5.4)(vue-tsc@2.1.10(typescript@5.5.4))(vue@3.4.31(typescript@5.5.4))(yaml@2.8.2)
       '@unhead/dom': 1.11.20
       '@unhead/shared': 1.11.20
       '@unhead/ssr': 1.11.20
@@ -15733,7 +15932,7 @@ snapshots:
 
   resolve@1.22.3:
     dependencies:
-      is-core-module: 2.12.1
+      is-core-module: 2.16.1
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
 
@@ -15764,11 +15963,11 @@ snapshots:
 
   rollup-plugin-terser@7.0.2(rollup@2.79.2):
     dependencies:
-      '@babel/code-frame': 7.27.1
+      '@babel/code-frame': 7.28.6
       jest-worker: 26.6.2
       rollup: 2.79.2
       serialize-javascript: 4.0.0
-      terser: 5.44.1
+      terser: 5.46.0
 
   rollup-plugin-visualizer@5.14.0(rollup@4.53.4):
     dependencies:
@@ -16447,12 +16646,30 @@ snapshots:
       jest-worker: 27.5.1
       schema-utils: 4.3.3
       serialize-javascript: 6.0.2
-      terser: 5.44.1
+      terser: 5.46.0
       webpack: 5.88.2(esbuild@0.23.0)
     optionalDependencies:
       esbuild: 0.23.0
 
+  terser-webpack-plugin@5.3.16(esbuild@0.25.12)(webpack@5.88.2(esbuild@0.25.12)):
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      jest-worker: 27.5.1
+      schema-utils: 4.3.3
+      serialize-javascript: 6.0.2
+      terser: 5.46.0
+      webpack: 5.88.2(esbuild@0.25.12)
+    optionalDependencies:
+      esbuild: 0.25.12
+
   terser@5.44.1:
+    dependencies:
+      '@jridgewell/source-map': 0.3.11
+      acorn: 8.15.0
+      commander: 2.20.3
+      source-map-support: 0.5.21
+
+  terser@5.46.0:
     dependencies:
       '@jridgewell/source-map': 0.3.11
       acorn: 8.15.0
@@ -16624,7 +16841,7 @@ snapshots:
       has-symbols: 1.1.0
       which-boxed-primitive: 1.1.1
 
-  unbuild@3.6.1(sass@1.77.8)(typescript@5.5.4)(vue-sfc-transformer@0.1.17(@vue/compiler-core@3.5.25)(esbuild@0.23.0)(vue@3.4.31(typescript@5.5.4)))(vue-tsc@2.1.10(typescript@5.5.4))(vue@3.4.31(typescript@5.5.4)):
+  unbuild@3.6.1(sass@1.77.8)(typescript@5.5.4)(vue-sfc-transformer@0.1.17(@vue/compiler-core@3.5.25)(esbuild@0.25.12)(vue@3.4.31(typescript@5.5.4)))(vue-tsc@2.1.10(typescript@5.5.4))(vue@3.4.31(typescript@5.5.4)):
     dependencies:
       '@rollup/plugin-alias': 5.1.1(rollup@4.53.4)
       '@rollup/plugin-commonjs': 28.0.9(rollup@4.53.4)
@@ -16640,7 +16857,7 @@ snapshots:
       hookable: 5.5.3
       jiti: 2.6.1
       magic-string: 0.30.21
-      mkdist: 2.4.1(sass@1.77.8)(typescript@5.5.4)(vue-sfc-transformer@0.1.17(@vue/compiler-core@3.5.25)(esbuild@0.23.0)(vue@3.4.31(typescript@5.5.4)))(vue-tsc@2.1.10(typescript@5.5.4))(vue@3.4.31(typescript@5.5.4))
+      mkdist: 2.4.1(sass@1.77.8)(typescript@5.5.4)(vue-sfc-transformer@0.1.17(@vue/compiler-core@3.5.25)(esbuild@0.25.12)(vue@3.4.31(typescript@5.5.4)))(vue-tsc@2.1.10(typescript@5.5.4))(vue@3.4.31(typescript@5.5.4))
       mlly: 1.8.0
       pathe: 2.0.3
       pkg-types: 2.3.0
@@ -16693,6 +16910,8 @@ snapshots:
       estree-walker: 3.0.3
       magic-string: 0.30.21
       unplugin: 2.3.11
+
+  undici-types@5.26.5: {}
 
   undici-types@6.19.8: {}
 
@@ -16796,9 +17015,9 @@ snapshots:
 
   universalify@2.0.1: {}
 
-  unocss@0.62.1(@unocss/webpack@0.62.1(rollup@2.79.2)(webpack@5.88.2(esbuild@0.23.0)))(postcss@8.5.6)(rollup@2.79.2)(vite@6.4.1(@types/node@20.6.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2)):
+  unocss@0.62.1(@unocss/webpack@0.62.1(rollup@2.79.2)(webpack@5.88.2(esbuild@0.25.12)))(postcss@8.5.6)(rollup@2.79.2)(vite@6.4.1(@types/node@20.6.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2)):
     dependencies:
-      '@unocss/astro': 0.62.1(rollup@2.79.2)(vite@6.4.1(@types/node@20.6.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2))
+      '@unocss/astro': 0.62.1(rollup@2.79.2)(vite@6.4.1(@types/node@20.6.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2))
       '@unocss/cli': 0.62.1(rollup@2.79.2)
       '@unocss/core': 0.62.1
       '@unocss/extractor-arbitrary-variants': 0.62.1
@@ -16817,18 +17036,18 @@ snapshots:
       '@unocss/transformer-compile-class': 0.62.1
       '@unocss/transformer-directives': 0.62.1
       '@unocss/transformer-variant-group': 0.62.1
-      '@unocss/vite': 0.62.1(rollup@2.79.2)(vite@6.4.1(@types/node@20.6.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2))
+      '@unocss/vite': 0.62.1(rollup@2.79.2)(vite@6.4.1(@types/node@20.6.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2))
     optionalDependencies:
-      '@unocss/webpack': 0.62.1(rollup@2.79.2)(webpack@5.88.2(esbuild@0.23.0))
-      vite: 6.4.1(@types/node@20.6.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2)
+      '@unocss/webpack': 0.62.1(rollup@2.79.2)(webpack@5.88.2(esbuild@0.25.12))
+      vite: 6.4.1(@types/node@20.6.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2)
     transitivePeerDependencies:
       - postcss
       - rollup
       - supports-color
 
-  unocss@0.62.4(@unocss/webpack@0.62.4(rollup@4.53.4)(webpack@5.88.2(esbuild@0.23.0)))(postcss@8.5.6)(rollup@4.53.4)(vite@6.4.1(@types/node@25.0.2)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2)):
+  unocss@0.62.4(@unocss/webpack@0.62.4(rollup@4.53.4)(webpack@5.88.2(esbuild@0.23.0)))(postcss@8.5.6)(rollup@4.53.4)(vite@6.4.1(@types/node@25.0.2)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2)):
     dependencies:
-      '@unocss/astro': 0.62.4(rollup@4.53.4)(vite@6.4.1(@types/node@25.0.2)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2))
+      '@unocss/astro': 0.62.4(rollup@4.53.4)(vite@6.4.1(@types/node@25.0.2)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2))
       '@unocss/cli': 0.62.4(rollup@4.53.4)
       '@unocss/core': 0.62.4
       '@unocss/postcss': 0.62.4(postcss@8.5.6)
@@ -16844,18 +17063,18 @@ snapshots:
       '@unocss/transformer-compile-class': 0.62.4
       '@unocss/transformer-directives': 0.62.4
       '@unocss/transformer-variant-group': 0.62.4
-      '@unocss/vite': 0.62.4(rollup@4.53.4)(vite@6.4.1(@types/node@25.0.2)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2))
+      '@unocss/vite': 0.62.4(rollup@4.53.4)(vite@6.4.1(@types/node@25.0.2)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2))
     optionalDependencies:
       '@unocss/webpack': 0.62.4(rollup@4.53.4)(webpack@5.88.2(esbuild@0.23.0))
-      vite: 6.4.1(@types/node@25.0.2)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2)
+      vite: 6.4.1(@types/node@25.0.2)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2)
     transitivePeerDependencies:
       - postcss
       - rollup
       - supports-color
 
-  unocss@66.5.10(@unocss/webpack@66.5.10(webpack@5.88.2(esbuild@0.23.0)))(postcss@8.5.6)(vite@6.4.1(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2)):
+  unocss@66.5.10(@unocss/webpack@66.5.10(webpack@5.88.2(esbuild@0.25.12)))(postcss@8.5.6)(vite@6.4.1(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2)):
     dependencies:
-      '@unocss/astro': 66.5.10(vite@6.4.1(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2))
+      '@unocss/astro': 66.5.10(vite@6.4.1(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2))
       '@unocss/cli': 66.5.10
       '@unocss/core': 66.5.10
       '@unocss/postcss': 66.5.10(postcss@8.5.6)
@@ -16873,17 +17092,17 @@ snapshots:
       '@unocss/transformer-compile-class': 66.5.10
       '@unocss/transformer-directives': 66.5.10
       '@unocss/transformer-variant-group': 66.5.10
-      '@unocss/vite': 66.5.10(vite@6.4.1(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2))
+      '@unocss/vite': 66.5.10(vite@6.4.1(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2))
     optionalDependencies:
-      '@unocss/webpack': 66.5.10(webpack@5.88.2(esbuild@0.23.0))
-      vite: 6.4.1(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2)
+      '@unocss/webpack': 66.5.10(webpack@5.88.2(esbuild@0.25.12))
+      vite: 6.4.1(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2)
     transitivePeerDependencies:
       - postcss
       - supports-color
 
-  unocss@66.5.10(@unocss/webpack@66.5.10(webpack@5.88.2(esbuild@0.23.0)))(postcss@8.5.6)(vite@6.4.1(@types/node@25.0.2)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2)):
+  unocss@66.5.10(@unocss/webpack@66.5.10(webpack@5.88.2(esbuild@0.25.12)))(postcss@8.5.6)(vite@6.4.1(@types/node@25.0.2)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2)):
     dependencies:
-      '@unocss/astro': 66.5.10(vite@6.4.1(@types/node@25.0.2)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2))
+      '@unocss/astro': 66.5.10(vite@6.4.1(@types/node@25.0.2)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2))
       '@unocss/cli': 66.5.10
       '@unocss/core': 66.5.10
       '@unocss/postcss': 66.5.10(postcss@8.5.6)
@@ -16901,10 +17120,10 @@ snapshots:
       '@unocss/transformer-compile-class': 66.5.10
       '@unocss/transformer-directives': 66.5.10
       '@unocss/transformer-variant-group': 66.5.10
-      '@unocss/vite': 66.5.10(vite@6.4.1(@types/node@25.0.2)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2))
+      '@unocss/vite': 66.5.10(vite@6.4.1(@types/node@25.0.2)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2))
     optionalDependencies:
-      '@unocss/webpack': 66.5.10(webpack@5.88.2(esbuild@0.23.0))
-      vite: 6.4.1(@types/node@25.0.2)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2)
+      '@unocss/webpack': 66.5.10(webpack@5.88.2(esbuild@0.25.12))
+      vite: 6.4.1(@types/node@25.0.2)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2)
     transitivePeerDependencies:
       - postcss
       - supports-color
@@ -17046,41 +17265,41 @@ snapshots:
 
   varint@6.0.0: {}
 
-  vite-dev-rpc@1.1.0(vite@6.4.1(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2)):
+  vite-dev-rpc@1.1.0(vite@6.4.1(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2)):
     dependencies:
       birpc: 2.9.0
-      vite: 6.4.1(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2)
-      vite-hot-client: 2.1.0(vite@6.4.1(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2))
+      vite: 6.4.1(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2)
+      vite-hot-client: 2.1.0(vite@6.4.1(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2))
 
-  vite-dev-rpc@1.1.0(vite@6.4.1(@types/node@25.0.2)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2)):
+  vite-dev-rpc@1.1.0(vite@6.4.1(@types/node@25.0.2)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2)):
     dependencies:
       birpc: 2.9.0
-      vite: 6.4.1(@types/node@25.0.2)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2)
-      vite-hot-client: 2.1.0(vite@6.4.1(@types/node@25.0.2)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2))
+      vite: 6.4.1(@types/node@25.0.2)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2)
+      vite-hot-client: 2.1.0(vite@6.4.1(@types/node@25.0.2)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2))
 
-  vite-hot-client@0.2.4(vite@6.4.1(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2)):
+  vite-hot-client@0.2.4(vite@6.4.1(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2)):
     dependencies:
-      vite: 6.4.1(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2)
+      vite: 6.4.1(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2)
 
-  vite-hot-client@0.2.4(vite@6.4.1(@types/node@25.0.2)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2)):
+  vite-hot-client@0.2.4(vite@6.4.1(@types/node@25.0.2)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2)):
     dependencies:
-      vite: 6.4.1(@types/node@25.0.2)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2)
+      vite: 6.4.1(@types/node@25.0.2)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2)
 
-  vite-hot-client@2.1.0(vite@6.4.1(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2)):
+  vite-hot-client@2.1.0(vite@6.4.1(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2)):
     dependencies:
-      vite: 6.4.1(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2)
+      vite: 6.4.1(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2)
 
-  vite-hot-client@2.1.0(vite@6.4.1(@types/node@25.0.2)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2)):
+  vite-hot-client@2.1.0(vite@6.4.1(@types/node@25.0.2)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2)):
     dependencies:
-      vite: 6.4.1(@types/node@25.0.2)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2)
+      vite: 6.4.1(@types/node@25.0.2)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2)
 
-  vite-node@3.2.4(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2):
+  vite-node@3.2.4(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 6.4.1(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2)
+      vite: 6.4.1(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -17095,13 +17314,13 @@ snapshots:
       - tsx
       - yaml
 
-  vite-node@3.2.4(@types/node@25.0.2)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2):
+  vite-node@3.2.4(@types/node@25.0.2)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 6.4.1(@types/node@25.0.2)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2)
+      vite: 6.4.1(@types/node@25.0.2)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -17116,7 +17335,7 @@ snapshots:
       - tsx
       - yaml
 
-  vite-plugin-checker@0.8.0(eslint@8.54.0)(optionator@0.9.3)(typescript@5.5.4)(vite@6.4.1(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2))(vue-tsc@2.1.10(typescript@5.5.4)):
+  vite-plugin-checker@0.8.0(eslint@8.54.0)(optionator@0.9.3)(typescript@5.5.4)(vite@6.4.1(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2))(vue-tsc@2.1.10(typescript@5.5.4)):
     dependencies:
       '@babel/code-frame': 7.27.1
       ansi-escapes: 4.3.2
@@ -17128,7 +17347,7 @@ snapshots:
       npm-run-path: 4.0.1
       strip-ansi: 6.0.1
       tiny-invariant: 1.3.3
-      vite: 6.4.1(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2)
+      vite: 6.4.1(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2)
       vscode-languageclient: 7.0.0
       vscode-languageserver: 7.0.0
       vscode-languageserver-textdocument: 1.0.12
@@ -17139,7 +17358,7 @@ snapshots:
       typescript: 5.5.4
       vue-tsc: 2.1.10(typescript@5.5.4)
 
-  vite-plugin-checker@0.8.0(eslint@8.54.0)(optionator@0.9.3)(typescript@5.5.4)(vite@6.4.1(@types/node@25.0.2)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2))(vue-tsc@2.1.10(typescript@5.5.4)):
+  vite-plugin-checker@0.8.0(eslint@8.54.0)(optionator@0.9.3)(typescript@5.5.4)(vite@6.4.1(@types/node@25.0.2)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2))(vue-tsc@2.1.10(typescript@5.5.4)):
     dependencies:
       '@babel/code-frame': 7.27.1
       ansi-escapes: 4.3.2
@@ -17151,7 +17370,7 @@ snapshots:
       npm-run-path: 4.0.1
       strip-ansi: 6.0.1
       tiny-invariant: 1.3.3
-      vite: 6.4.1(@types/node@25.0.2)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2)
+      vite: 6.4.1(@types/node@25.0.2)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2)
       vscode-languageclient: 7.0.0
       vscode-languageserver: 7.0.0
       vscode-languageserver-textdocument: 1.0.12
@@ -17162,7 +17381,7 @@ snapshots:
       typescript: 5.5.4
       vue-tsc: 2.1.10(typescript@5.5.4)
 
-  vite-plugin-inspect@0.8.9(@nuxt/kit@3.15.4(magicast@0.5.1))(rollup@4.53.4)(vite@6.4.1(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2)):
+  vite-plugin-inspect@0.8.9(@nuxt/kit@3.15.4(magicast@0.5.1))(rollup@4.53.4)(vite@6.4.1(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2)):
     dependencies:
       '@antfu/utils': 0.7.10
       '@rollup/pluginutils': 5.3.0(rollup@4.53.4)
@@ -17173,14 +17392,14 @@ snapshots:
       perfect-debounce: 1.0.0
       picocolors: 1.1.1
       sirv: 3.0.2
-      vite: 6.4.1(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2)
+      vite: 6.4.1(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2)
     optionalDependencies:
       '@nuxt/kit': 3.15.4(magicast@0.5.1)
     transitivePeerDependencies:
       - rollup
       - supports-color
 
-  vite-plugin-inspect@0.8.9(@nuxt/kit@3.15.4(magicast@0.5.1))(rollup@4.53.4)(vite@6.4.1(@types/node@25.0.2)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2)):
+  vite-plugin-inspect@0.8.9(@nuxt/kit@3.15.4(magicast@0.5.1))(rollup@4.53.4)(vite@6.4.1(@types/node@25.0.2)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2)):
     dependencies:
       '@antfu/utils': 0.7.10
       '@rollup/pluginutils': 5.3.0(rollup@4.53.4)
@@ -17191,14 +17410,14 @@ snapshots:
       perfect-debounce: 1.0.0
       picocolors: 1.1.1
       sirv: 3.0.2
-      vite: 6.4.1(@types/node@25.0.2)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2)
+      vite: 6.4.1(@types/node@25.0.2)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2)
     optionalDependencies:
       '@nuxt/kit': 3.15.4(magicast@0.5.1)
     transitivePeerDependencies:
       - rollup
       - supports-color
 
-  vite-plugin-inspect@11.3.3(@nuxt/kit@3.15.4(magicast@0.5.1))(vite@6.4.1(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2)):
+  vite-plugin-inspect@11.3.3(@nuxt/kit@3.15.4(magicast@0.5.1))(vite@6.4.1(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2)):
     dependencies:
       ansis: 4.2.0
       debug: 4.4.3
@@ -17208,14 +17427,14 @@ snapshots:
       perfect-debounce: 2.0.0
       sirv: 3.0.2
       unplugin-utils: 0.3.1
-      vite: 6.4.1(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2)
-      vite-dev-rpc: 1.1.0(vite@6.4.1(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2))
+      vite: 6.4.1(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2)
+      vite-dev-rpc: 1.1.0(vite@6.4.1(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2))
     optionalDependencies:
       '@nuxt/kit': 3.15.4(magicast@0.5.1)
     transitivePeerDependencies:
       - supports-color
 
-  vite-plugin-inspect@11.3.3(@nuxt/kit@3.15.4(magicast@0.5.1))(vite@6.4.1(@types/node@25.0.2)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2)):
+  vite-plugin-inspect@11.3.3(@nuxt/kit@3.15.4(magicast@0.5.1))(vite@6.4.1(@types/node@25.0.2)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2)):
     dependencies:
       ansis: 4.2.0
       debug: 4.4.3
@@ -17225,19 +17444,19 @@ snapshots:
       perfect-debounce: 2.0.0
       sirv: 3.0.2
       unplugin-utils: 0.3.1
-      vite: 6.4.1(@types/node@25.0.2)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2)
-      vite-dev-rpc: 1.1.0(vite@6.4.1(@types/node@25.0.2)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2))
+      vite: 6.4.1(@types/node@25.0.2)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2)
+      vite-dev-rpc: 1.1.0(vite@6.4.1(@types/node@25.0.2)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2))
     optionalDependencies:
       '@nuxt/kit': 3.15.4(magicast@0.5.1)
     transitivePeerDependencies:
       - supports-color
 
-  vite-plugin-pwa@0.20.1(@vite-pwa/assets-generator@0.2.4)(vite@6.4.1(@types/node@20.6.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2))(workbox-build@7.0.0)(workbox-window@7.1.0):
+  vite-plugin-pwa@0.20.1(@vite-pwa/assets-generator@0.2.4)(vite@6.4.1(@types/node@20.6.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2))(workbox-build@7.0.0)(workbox-window@7.1.0):
     dependencies:
       debug: 4.3.6
       pretty-bytes: 6.1.1
       tinyglobby: 0.2.2
-      vite: 6.4.1(@types/node@20.6.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2)
+      vite: 6.4.1(@types/node@20.6.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2)
       workbox-build: 7.0.0
       workbox-window: 7.1.0
     optionalDependencies:
@@ -17245,7 +17464,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  vite-plugin-vue-inspector@5.3.2(vite@6.4.1(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2)):
+  vite-plugin-vue-inspector@5.3.2(vite@6.4.1(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2)):
     dependencies:
       '@babel/core': 7.28.5
       '@babel/plugin-proposal-decorators': 7.28.0(@babel/core@7.28.5)
@@ -17256,11 +17475,11 @@ snapshots:
       '@vue/compiler-dom': 3.5.25
       kolorist: 1.8.0
       magic-string: 0.30.21
-      vite: 6.4.1(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2)
+      vite: 6.4.1(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2)
     transitivePeerDependencies:
       - supports-color
 
-  vite-plugin-vue-inspector@5.3.2(vite@6.4.1(@types/node@25.0.2)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2)):
+  vite-plugin-vue-inspector@5.3.2(vite@6.4.1(@types/node@25.0.2)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2)):
     dependencies:
       '@babel/core': 7.28.5
       '@babel/plugin-proposal-decorators': 7.28.0(@babel/core@7.28.5)
@@ -17271,42 +17490,42 @@ snapshots:
       '@vue/compiler-dom': 3.5.25
       kolorist: 1.8.0
       magic-string: 0.30.21
-      vite: 6.4.1(@types/node@25.0.2)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2)
+      vite: 6.4.1(@types/node@25.0.2)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2)
     transitivePeerDependencies:
       - supports-color
 
-  vite-plugin-vue-tracer@1.1.3(vite@6.4.1(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2))(vue@3.4.31(typescript@5.5.4)):
+  vite-plugin-vue-tracer@1.1.3(vite@6.4.1(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2))(vue@3.4.31(typescript@5.5.4)):
     dependencies:
       estree-walker: 3.0.3
       exsolve: 1.0.8
       magic-string: 0.30.21
       pathe: 2.0.3
       source-map-js: 1.2.1
-      vite: 6.4.1(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2)
+      vite: 6.4.1(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2)
       vue: 3.4.31(typescript@5.5.4)
 
-  vite-plugin-vue-tracer@1.1.3(vite@6.4.1(@types/node@25.0.2)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2))(vue@3.4.31(typescript@5.5.4)):
+  vite-plugin-vue-tracer@1.1.3(vite@6.4.1(@types/node@25.0.2)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2))(vue@3.4.31(typescript@5.5.4)):
     dependencies:
       estree-walker: 3.0.3
       exsolve: 1.0.8
       magic-string: 0.30.21
       pathe: 2.0.3
       source-map-js: 1.2.1
-      vite: 6.4.1(@types/node@25.0.2)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2)
+      vite: 6.4.1(@types/node@25.0.2)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2)
       vue: 3.4.31(typescript@5.5.4)
 
-  vite-plugin-vuetify@2.1.2(vite@6.4.1(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2))(vue@3.4.31(typescript@5.5.4))(vuetify@3.7.0):
+  vite-plugin-vuetify@2.1.3(vite@6.4.1(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2))(vue@3.4.31(typescript@5.5.4))(vuetify@3.7.0):
     dependencies:
-      '@vuetify/loader-shared': 2.1.1(vue@3.4.31(typescript@5.5.4))(vuetify@3.7.0)
+      '@vuetify/loader-shared': 2.1.2(vue@3.4.31(typescript@5.5.4))(vuetify@3.7.0)
       debug: 4.4.3
       upath: 2.0.1
-      vite: 6.4.1(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2)
+      vite: 6.4.1(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2)
       vue: 3.4.31(typescript@5.5.4)
-      vuetify: 3.7.0(typescript@5.5.4)(vite-plugin-vuetify@2.1.2)(vue-i18n@9.10.2(vue@3.4.31(typescript@5.5.4)))(vue@3.4.31(typescript@5.5.4))
+      vuetify: 3.7.0(typescript@5.5.4)(vite-plugin-vuetify@2.1.3)(vue-i18n@9.10.2(vue@3.4.31(typescript@5.5.4)))(vue@3.4.31(typescript@5.5.4))
     transitivePeerDependencies:
       - supports-color
 
-  vite@6.4.1(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2):
+  vite@6.4.1(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2):
     dependencies:
       esbuild: 0.25.12
       fdir: 6.5.0(picomatch@4.0.3)
@@ -17320,11 +17539,11 @@ snapshots:
       jiti: 2.6.1
       sass: 1.77.8
       sass-embedded: 1.77.8
-      terser: 5.44.1
+      terser: 5.46.0
       tsx: 4.17.0
       yaml: 2.8.2
 
-  vite@6.4.1(@types/node@20.6.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2):
+  vite@6.4.1(@types/node@20.6.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2):
     dependencies:
       esbuild: 0.25.12
       fdir: 6.5.0(picomatch@4.0.3)
@@ -17338,11 +17557,11 @@ snapshots:
       jiti: 2.6.1
       sass: 1.77.8
       sass-embedded: 1.77.8
-      terser: 5.44.1
+      terser: 5.46.0
       tsx: 4.17.0
       yaml: 2.8.2
 
-  vite@6.4.1(@types/node@25.0.2)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2):
+  vite@6.4.1(@types/node@25.0.2)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2):
     dependencies:
       esbuild: 0.25.12
       fdir: 6.5.0(picomatch@4.0.3)
@@ -17356,18 +17575,18 @@ snapshots:
       jiti: 2.6.1
       sass: 1.77.8
       sass-embedded: 1.77.8
-      terser: 5.44.1
+      terser: 5.46.0
       tsx: 4.17.0
       yaml: 2.8.2
 
-  vitepress@1.3.2(@algolia/client-search@4.19.1)(@types/node@20.6.0)(jiti@2.6.1)(postcss@8.5.6)(sass-embedded@1.77.8)(sass@1.77.8)(search-insights@2.7.0)(terser@5.44.1)(tsx@4.17.0)(typescript@5.5.4)(yaml@2.8.2):
+  vitepress@1.3.2(@algolia/client-search@4.19.1)(@types/node@20.6.0)(jiti@2.6.1)(postcss@8.5.6)(sass-embedded@1.77.8)(sass@1.77.8)(search-insights@2.7.0)(terser@5.46.0)(tsx@4.17.0)(typescript@5.5.4)(yaml@2.8.2):
     dependencies:
       '@docsearch/css': 3.6.0
       '@docsearch/js': 3.6.0(@algolia/client-search@4.19.1)(search-insights@2.7.0)
       '@shikijs/core': 1.13.0
       '@shikijs/transformers': 1.13.0
       '@types/markdown-it': 14.1.2
-      '@vitejs/plugin-vue': 5.0.5(vite@6.4.1(@types/node@20.6.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2))(vue@3.4.31(typescript@5.5.4))
+      '@vitejs/plugin-vue': 5.0.5(vite@6.4.1(@types/node@20.6.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2))(vue@3.4.31(typescript@5.5.4))
       '@vue/devtools-api': 7.3.8
       '@vue/shared': 3.4.38
       '@vueuse/core': 10.11.1(vue@3.4.31(typescript@5.5.4))
@@ -17376,7 +17595,7 @@ snapshots:
       mark.js: 8.11.1
       minisearch: 7.1.0
       shiki: 1.13.0
-      vite: 6.4.1(@types/node@20.6.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2)
+      vite: 6.4.1(@types/node@20.6.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2)
       vue: 3.4.31(typescript@5.5.4)
     optionalDependencies:
       postcss: 8.5.6
@@ -17411,9 +17630,9 @@ snapshots:
       - universal-cookie
       - yaml
 
-  vitest-environment-nuxt@1.0.0(h3@1.15.4)(magicast@0.5.1)(nitropack@2.12.9(encoding@0.1.13))(vite@6.4.1(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2))(vitest@3.2.4(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2))(vue-router@4.6.4(vue@3.4.31(typescript@5.5.4)))(vue@3.4.31(typescript@5.5.4)):
+  vitest-environment-nuxt@1.0.0(h3@1.15.4)(magicast@0.5.1)(nitropack@2.12.9(encoding@0.1.13))(vite@6.4.1(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2))(vitest@3.2.4(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2))(vue-router@4.6.4(vue@3.4.31(typescript@5.5.4)))(vue@3.4.31(typescript@5.5.4)):
     dependencies:
-      '@nuxt/test-utils': 3.13.1(h3@1.15.4)(magicast@0.5.1)(nitropack@2.12.9(encoding@0.1.13))(vite@6.4.1(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2))(vitest@3.2.4(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2))(vue-router@4.6.4(vue@3.4.31(typescript@5.5.4)))(vue@3.4.31(typescript@5.5.4))
+      '@nuxt/test-utils': 3.13.1(h3@1.15.4)(magicast@0.5.1)(nitropack@2.12.9(encoding@0.1.13))(vite@6.4.1(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2))(vitest@3.2.4(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2))(vue-router@4.6.4(vue@3.4.31(typescript@5.5.4)))(vue@3.4.31(typescript@5.5.4))
     transitivePeerDependencies:
       - '@cucumber/cucumber'
       - '@jest/globals'
@@ -17433,11 +17652,11 @@ snapshots:
       - vue
       - vue-router
 
-  vitest@3.2.4(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2):
+  vitest@3.2.4(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@6.4.1(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2))
+      '@vitest/mocker': 3.2.4(vite@6.4.1(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -17455,8 +17674,8 @@ snapshots:
       tinyglobby: 0.2.15
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 6.4.1(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2)
-      vite-node: 3.2.4(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2)
+      vite: 6.4.1(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2)
+      vite-node: 3.2.4(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 18.0.0
@@ -17539,11 +17758,11 @@ snapshots:
       '@vue/devtools-api': 6.6.4
       vue: 3.4.31(typescript@5.5.4)
 
-  vue-sfc-transformer@0.1.17(@vue/compiler-core@3.5.25)(esbuild@0.23.0)(vue@3.4.31(typescript@5.5.4)):
+  vue-sfc-transformer@0.1.17(@vue/compiler-core@3.5.25)(esbuild@0.25.12)(vue@3.4.31(typescript@5.5.4)):
     dependencies:
       '@babel/parser': 7.28.5
       '@vue/compiler-core': 3.5.25
-      esbuild: 0.23.0
+      esbuild: 0.25.12
       vue: 3.4.31(typescript@5.5.4)
 
   vue-tsc@2.1.10(typescript@5.5.4):
@@ -17563,15 +17782,15 @@ snapshots:
     optionalDependencies:
       typescript: 5.5.4
 
-  vuetify@3.7.0(typescript@5.5.4)(vite-plugin-vuetify@2.1.2)(vue-i18n@9.10.2(vue@3.4.31(typescript@5.5.4)))(vue@3.4.31(typescript@5.5.4)):
+  vuetify@3.7.0(typescript@5.5.4)(vite-plugin-vuetify@2.1.3)(vue-i18n@9.10.2(vue@3.4.31(typescript@5.5.4)))(vue@3.4.31(typescript@5.5.4)):
     dependencies:
       vue: 3.4.31(typescript@5.5.4)
     optionalDependencies:
       typescript: 5.5.4
-      vite-plugin-vuetify: 2.1.2(vite@6.4.1(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.44.1)(tsx@4.17.0)(yaml@2.8.2))(vue@3.4.31(typescript@5.5.4))(vuetify@3.7.0)
+      vite-plugin-vuetify: 2.1.3(vite@6.4.1(@types/node@18.0.0)(jiti@2.6.1)(sass-embedded@1.77.8)(sass@1.77.8)(terser@5.46.0)(tsx@4.17.0)(yaml@2.8.2))(vue@3.4.31(typescript@5.5.4))(vuetify@3.7.0)
       vue-i18n: 9.10.2(vue@3.4.31(typescript@5.5.4))
 
-  watchpack@2.4.4:
+  watchpack@2.5.1:
     dependencies:
       glob-to-regexp: 0.4.1
       graceful-fs: 4.2.11
@@ -17610,7 +17829,38 @@ snapshots:
       schema-utils: 3.3.0
       tapable: 2.3.0
       terser-webpack-plugin: 5.3.16(esbuild@0.23.0)(webpack@5.88.2(esbuild@0.23.0))
-      watchpack: 2.4.4
+      watchpack: 2.5.1
+      webpack-sources: 3.3.3
+    transitivePeerDependencies:
+      - '@swc/core'
+      - esbuild
+      - uglify-js
+
+  webpack@5.88.2(esbuild@0.25.12):
+    dependencies:
+      '@types/eslint-scope': 3.7.7
+      '@types/estree': 1.0.8
+      '@webassemblyjs/ast': 1.14.1
+      '@webassemblyjs/wasm-edit': 1.14.1
+      '@webassemblyjs/wasm-parser': 1.14.1
+      acorn: 8.15.0
+      acorn-import-assertions: 1.9.0(acorn@8.15.0)
+      browserslist: 4.28.1
+      chrome-trace-event: 1.0.4
+      enhanced-resolve: 5.18.4
+      es-module-lexer: 1.7.0
+      eslint-scope: 5.1.1
+      events: 3.3.0
+      glob-to-regexp: 0.4.1
+      graceful-fs: 4.2.11
+      json-parse-even-better-errors: 2.3.1
+      loader-runner: 4.3.1
+      mime-types: 2.1.35
+      neo-async: 2.6.2
+      schema-utils: 3.3.0
+      tapable: 2.3.0
+      terser-webpack-plugin: 5.3.16(esbuild@0.25.12)(webpack@5.88.2(esbuild@0.25.12))
+      watchpack: 2.5.1
       webpack-sources: 3.3.3
     transitivePeerDependencies:
       - '@swc/core'
@@ -17650,7 +17900,7 @@ snapshots:
       isarray: 2.0.5
       which-boxed-primitive: 1.1.1
       which-collection: 1.0.2
-      which-typed-array: 1.1.19
+      which-typed-array: 1.1.20
 
   which-collection@1.0.2:
     dependencies:
@@ -17659,7 +17909,7 @@ snapshots:
       is-weakmap: 2.0.2
       is-weakset: 2.0.4
 
-  which-typed-array@1.1.19:
+  which-typed-array@1.1.20:
     dependencies:
       available-typed-arrays: 1.0.7
       call-bind: 1.0.8
@@ -17698,10 +17948,10 @@ snapshots:
   workbox-build@7.0.0:
     dependencies:
       '@apideck/better-ajv-errors': 0.3.6(ajv@8.17.1)
-      '@babel/core': 7.28.5
-      '@babel/preset-env': 7.28.5(@babel/core@7.28.5)
-      '@babel/runtime': 7.28.4
-      '@rollup/plugin-babel': 5.3.1(@babel/core@7.28.5)(rollup@2.79.2)
+      '@babel/core': 7.28.6
+      '@babel/preset-env': 7.28.6(@babel/core@7.28.6)
+      '@babel/runtime': 7.28.6
+      '@rollup/plugin-babel': 5.3.1(@babel/core@7.28.6)(rollup@2.79.2)
       '@rollup/plugin-node-resolve': 11.2.1(rollup@2.79.2)
       '@rollup/plugin-replace': 2.4.2(rollup@2.79.2)
       '@surma/rollup-plugin-off-main-thread': 2.2.3


### PR DESCRIPTION
### Description

Use relaxed version for nuxt/kit, allow vuetify version to be 4 (with the vite-plugin-vuetify update and version range), use fresh versions for unconfig and local-pkg

### Linked Issues

fixes #341 

### Additional Context

<!-- Is there anything you would like the reviewers to focus on? -->

---

> [!TIP]
> The author of this PR can publish a _preview release_ by commenting `/publish` below.
