### PR TITLE
fix(styles): write vuetify settings scss file to disk

### DIFF
--- a/packages/vuetify-nuxt-module/src/utils/configure-nuxt.ts
+++ b/packages/vuetify-nuxt-module/src/utils/configure-nuxt.ts
@@ -31,10 +31,10 @@ export async function configureNuxt (
   if (styles !== 'none' && (styles as any) !== false) {
     nuxt.options.css ??= []
     if (typeof styles === 'object' && 'configFile' in styles) {
-      const configFile = resolveVuetifyConfigFile(styles.configFile, nuxt)
-      ctx.stylesConfigFile = await resolvePath(configFile)
+      ctx.stylesConfigFile = resolveVuetifyConfigFile(styles.configFile, nuxt)
       const a = addTemplate({
-        filename: 'vuetify.settings.scss',
+        write: true,
+        filename: 'vuetify/vuetify.settings.scss',
         getContents: async () => getTemplate('vuetify/styles', ctx.stylesConfigFile!),
       })
       nuxt.options.css.push(a.dst)


### PR DESCRIPTION


### Description

The `vuetify.settings.scss` file saved to `.nuxt/vuetify folder`.

@AndreyYolkin this change should also be applied to unplugin styles.
<!-- Please insert your description here and provide info about the "what" this PR is solving. -->

### Linked Issues

fixes #363

<!-- e.g. fixes #123 -->

### Additional Context

<!-- Is there anything you would like the reviewers to focus on? -->

---

> [!TIP]
> The author of this PR can publish a _preview release_ by commenting `/publish` below.
