### PR TITLE
fix(styles): write vuetify settings scss file to disk

### DIFF
--- a/packages/vuetify-nuxt-module/src/utils/configure-nuxt.ts
+++ b/packages/vuetify-nuxt-module/src/utils/configure-nuxt.ts
@@ -34,7 +34,11 @@ export async function configureNuxt (
       const configFile = resolveVuetifyConfigFile(styles.configFile, nuxt)
       ctx.stylesConfigFile = await resolvePath(configFile)
       const a = addTemplate({
-        filename: 'vuetify.settings.scss',
+        // Write to disk: without `write` Nuxt serves the template from its
+        // virtual FS, which 404s on Windows/SSR when the browser requests the
+        // real file (#363). Nest under `vuetify/` to match unplugin-styles.
+        write: true,
+        filename: 'vuetify/vuetify.settings.scss',
         getContents: async () => getTemplate('vuetify/styles', ctx.stylesConfigFile!),
       })
       nuxt.options.css.push(a.dst)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -109,8 +109,8 @@ catalogs:
       specifier: ^1.1.0
       version: 1.1.0
     '@vuetify/unplugin-styles':
-      specifier: ^1.0.0-beta.10
-      version: 1.0.0-beta.10
+      specifier: ^1.0.0-beta.11
+      version: 1.0.0-beta.11
     bumpp:
       specifier: ^10.4.1
       version: 10.4.1
@@ -451,7 +451,7 @@ importers:
         version: 4.4.2(magicast@0.5.2)
       '@vuetify/unplugin-styles':
         specifier: 'catalog:'
-        version: 1.0.0-beta.10(@nuxt/kit@4.4.2(magicast@0.5.2))(@nuxt/schema@4.3.1)(sass-embedded@1.97.3)(sass@1.97.3)(vite@7.3.1(@types/node@25.3.3)(jiti@2.6.1)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.88.2(esbuild@0.27.3))
+        version: 1.0.0-beta.11(@nuxt/kit@4.4.2(magicast@0.5.2))(@nuxt/schema@4.3.1)(sass-embedded@1.97.3)(sass@1.97.3)(vite@7.3.1(@types/node@25.3.3)(jiti@2.6.1)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.88.2(esbuild@0.27.3))
       defu:
         specifier: 'catalog:'
         version: 6.1.4
@@ -3798,8 +3798,8 @@ packages:
       vue: ^3.0.0
       vuetify: '>=3'
 
-  '@vuetify/unplugin-styles@1.0.0-beta.10':
-    resolution: {integrity: sha512-3fpGIPqlV4MC+hetWJkPPz0C1AyiE1HIIkI++slB3UHrETlMCSn0kpfdGwW4VohXj53TNnVI5s3IImOIvAaEYg==}
+  '@vuetify/unplugin-styles@1.0.0-beta.11':
+    resolution: {integrity: sha512-cMqc4HVOmR4IvqrBJ+jVen7OVht32RvjM2f46OG07nVWwmumH4j6Vr9S+q+kl3frtxjVIZyEosl4a43VPGZUQQ==}
     engines: {node: '>=22'}
     peerDependencies:
       '@nuxt/kit': ^3 || ^4
@@ -11837,7 +11837,7 @@ snapshots:
       vue: 3.5.29(typescript@5.9.3)
       vuetify: 4.0.1(typescript@5.9.3)(vite-plugin-vuetify@2.1.3)(vue@3.5.29(typescript@5.9.3))
 
-  '@vuetify/unplugin-styles@1.0.0-beta.10(@nuxt/kit@4.4.2(magicast@0.5.2))(@nuxt/schema@4.3.1)(sass-embedded@1.97.3)(sass@1.97.3)(vite@7.3.1(@types/node@25.3.3)(jiti@2.6.1)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.88.2(esbuild@0.27.3))':
+  '@vuetify/unplugin-styles@1.0.0-beta.11(@nuxt/kit@4.4.2(magicast@0.5.2))(@nuxt/schema@4.3.1)(sass-embedded@1.97.3)(sass@1.97.3)(vite@7.3.1(@types/node@25.3.3)(jiti@2.6.1)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.88.2(esbuild@0.27.3))':
     dependencies:
       pathe: 2.0.3
       semver: 7.7.4

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -38,7 +38,7 @@ catalog:
   '@unocss/nuxt': ^66.6.5
   '@vite-pwa/assets-generator': ^1.0.2
   '@vite-pwa/vitepress': ^1.1.0
-  '@vuetify/unplugin-styles': ^1.0.0-beta.10
+  '@vuetify/unplugin-styles': ^1.0.0-beta.11
   bumpp: ^10.4.1
   conventional-github-releaser: ^3.1.5
   date-fns: ^4.1.0


### PR DESCRIPTION
### Description

`addTemplate` without `write: true` serves the generated `vuetify.settings.scss` from Nuxt's virtual FS. On Windows/SSR the browser requests the **real** file under `_nuxt/.../.nuxt/...` and gets a **404** (#363).

This writes the file to disk under `.nuxt/vuetify/vuetify.settings.scss`, matching `@vuetify/unplugin-styles`.

Same essential fix as #364, but **keeps the `await resolvePath(configFile)` call** so aliased `configFile` values still resolve. The playground itself uses `configFile: '~/assets/custom-vuetify.scss'` — dropping `resolvePath` (as #364 does) would emit `@use '~/assets/...'` and break sass. This way aliases keep working **and** layers are still honoured via `resolveVuetifyConfigFile`.

Also bumps `@vuetify/unplugin-styles` catalog `^1.0.0-beta.10 → ^1.0.0-beta.11`.

### Linked Issues

fixes #363

### Verification

- `pnpm test` — 27 passed (11 files)
- `apps/playground` dev server: `vuetify.settings.scss` now returns **200** (was 404); page styled; no scss/styles console errors
- Confirmed generated file resolves the `~/` alias to an absolute path on disk

### Additional Context

Consolidating nuxt-module's styles handling onto `@vuetify/unplugin-styles/nuxt` (via `installModule`) is a planned follow-up; this PR is the minimal hotfix for #363.