### PR TITLE
fix: resolve vuetify & optional deps without relying on cwd

### DIFF
--- a/packages/vuetify-nuxt-module/src/module.ts
+++ b/packages/vuetify-nuxt-module/src/module.ts
@@ -7,15 +7,18 @@ import type {
   VuetifyModuleOptions,
 } from './types'
 import type { VuetifyNuxtContext } from './utils/config'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
 import {
   createResolver,
   defineNuxtModule,
+  findPath,
   getNuxtVersion,
   hasNuxtModule,
   isNuxtMajorVersion,
   useLogger,
 } from '@nuxt/kit'
-import { getPackageInfo } from 'local-pkg'
+import { dirname } from 'pathe'
 import semver from 'semver'
 import { version as VITE_VERSION } from 'vite'
 import { version } from '../package.json'
@@ -118,8 +121,26 @@ export default defineNuxtModule<ModuleOptions>({
       logger.error(`Cannot support nuxt version: ${getNuxtVersion(nuxt)}`)
     }
 
-    const vuetifyPkg = await getPackageInfo('vuetify')
-    const currentVersion = vuetifyPkg?.version
+    // Resolve `vuetify` via Nuxt (honours layers/modulesDir), then fall back to the
+    // module's own dependency for pnpm isolated installs and external layers (#277, #306).
+    let vuetifyPkgPath = await findPath('vuetify/package.json')
+    if (!vuetifyPkgPath) {
+      const metaResolve = (import.meta as { resolve?: (id: string) => string }).resolve
+      if (metaResolve) {
+        try {
+          vuetifyPkgPath = fileURLToPath(metaResolve('vuetify/package.json'))
+        } catch {
+          // unresolved: handled by the guard below
+        }
+      }
+    }
+    if (!vuetifyPkgPath) {
+      throw new Error(
+        '[vuetify-nuxt-module] Could not resolve "vuetify". Please add it as a dependency of your project (e.g. `npm add vuetify`).',
+      )
+    }
+    const vuetifyBase = dirname(vuetifyPkgPath)
+    const currentVersion: string | undefined = JSON.parse(readFileSync(vuetifyPkgPath, 'utf8')).version
     const vuetifyGte = (version: string) =>
       !!currentVersion && semver.gte(currentVersion, version)
 
@@ -142,6 +163,8 @@ export default defineNuxtModule<ModuleOptions>({
       labComponentsPromise: undefined!,
       vuetifyGte,
       vuetifyVersion: currentVersion || '0.0.0',
+      vuetifyBase,
+      resolvePaths: [nuxt.options.rootDir, ...nuxt.options.modulesDir],
       viteVersion,
     }
 

--- a/packages/vuetify-nuxt-module/src/utils/config.ts
+++ b/packages/vuetify-nuxt-module/src/utils/config.ts
@@ -31,6 +31,10 @@ export interface VuetifyNuxtContext {
    */
   vuetifyGte: (version: string) => boolean
   vuetifyVersion: string
+  /** Absolute path to the resolved `vuetify` package root. */
+  vuetifyBase: string
+  /** Project resolution paths (`rootDir` + `modulesDir`) for detecting optional deps under pnpm/layers (#277, #306). */
+  resolvePaths: string[]
   viteVersion: string
   enableRules?: boolean
   rulesConfiguration?: { fromLabs?: boolean, configFile?: string }

--- a/packages/vuetify-nuxt-module/src/utils/configure-vite.ts
+++ b/packages/vuetify-nuxt-module/src/utils/configure-vite.ts
@@ -1,7 +1,6 @@
 import type { Nuxt } from '@nuxt/schema'
 import type { ObjectImportPluginOptions } from '@vuetify/loader-shared'
 import type { VuetifyNuxtContext } from './config'
-import { isObject } from '@vuetify/loader-shared'
 import Styles from '@vuetify/unplugin-styles/vite'
 import defu from 'defu'
 import { isPackageExists } from 'local-pkg'
@@ -28,7 +27,7 @@ export function configureVite (configKey: string, nuxt: Nuxt, ctx: VuetifyNuxtCo
       // vite version >= 5.4.0 && < 7.0.0
       const enableModernSassCompiler = semver.gte(ctx.viteVersion, '5.4.0') && semver.lt(ctx.viteVersion, '7.0.0-0')
       if (enableModernSassCompiler) {
-        const sassEmbedded = isPackageExists('sass-embedded')
+        const sassEmbedded = isPackageExists('sass-embedded', { paths: ctx.resolvePaths })
         if (sassEmbedded) {
           viteInlineConfig.css ??= {}
           viteInlineConfig.css.preprocessorOptions ??= {}
@@ -89,7 +88,7 @@ export function configureVite (configKey: string, nuxt: Nuxt, ctx: VuetifyNuxtCo
     const stylesOption = ctx.moduleOptions.styles
     if (stylesOption === 'none') {
       viteInlineConfig.plugins.push(Styles({ styles: 'none' }))
-    } else if (isObject(stylesOption) && 'configFile' in stylesOption) {
+    } else if (typeof stylesOption === 'object' && stylesOption !== null && 'configFile' in stylesOption) {
       if (!ctx.stylesConfigFile) {
         throw new Error('vuetify-nuxt-module: styles.configFile could not be resolved')
       }

--- a/packages/vuetify-nuxt-module/src/utils/icons.ts
+++ b/packages/vuetify-nuxt-module/src/utils/icons.ts
@@ -60,7 +60,9 @@ export function prepareIcons (
   unocssPresent: boolean,
   logger: ReturnType<typeof import('@nuxt/kit')['useLogger']>,
   vuetifyOptions: VOptions,
+  paths: string[],
 ): ResolvedIcons {
+  const iconPackageExists = (name: string) => isPackageExists(name, { paths })
   if (vuetifyOptions.icons === false) {
     return disabledResolvedIcons
   }
@@ -113,7 +115,7 @@ export function prepareIcons (
 
       resolvedIcons.imports.push(`import {${name === defaultSet ? 'aliases,' : ''}${name}} from 'vuetify/iconsets/${name}'`)
       resolvedIcons.sets.push(name)
-      if (isPackageExists(iconsPackageNames[name].name)) {
+      if (iconPackageExists(iconsPackageNames[name].name)) {
         resolvedIcons.local.push(iconsPackageNames[name].css)
       } else {
         resolvedIcons.cdn.push([name, cdn ?? iconsCDN[name]])
@@ -135,12 +137,12 @@ export function prepareIcons (
       faSvg = {}
     }
 
-    let faSvgExists = isPackageExists('@fortawesome/fontawesome-svg-core')
+    let faSvgExists = iconPackageExists('@fortawesome/fontawesome-svg-core')
     if (!faSvgExists) {
       logger.warn('Missing @fortawesome/fontawesome-svg-core dependency, install it!')
     }
 
-    faSvgExists = isPackageExists('@fortawesome/vue-fontawesome')
+    faSvgExists = iconPackageExists('@fortawesome/vue-fontawesome')
     if (faSvgExists) {
       if (!faSvg.libraries?.length) {
         faSvg.libraries = [[false, 'fas', '@fortawesome/free-solid-svg-icons']]
@@ -148,7 +150,7 @@ export function prepareIcons (
 
       for (const p in faSvg.libraries) {
         const [_defaultExport, _name, library] = faSvg.libraries[p]
-        if (!isPackageExists(library)) {
+        if (!iconPackageExists(library)) {
           faSvgExists = false
           logger.warn(`Missing library ${library} dependency, install it!`)
         }
@@ -178,7 +180,7 @@ export function prepareIcons (
       mdiSvg = {}
     }
 
-    const mdiSvgExists = isPackageExists('@mdi/js')
+    const mdiSvgExists = iconPackageExists('@mdi/js')
     if (mdiSvgExists) {
       resolvedIcons.svg.mdi = true
       resolvedIcons.aliasesImportPresent ||= defaultSet === 'mdi-svg'

--- a/packages/vuetify-nuxt-module/src/utils/loader.ts
+++ b/packages/vuetify-nuxt-module/src/utils/loader.ts
@@ -27,7 +27,7 @@ export async function load (
     const {
       componentsPromise,
       labComponentsPromise,
-    } = resolveVuetifyComponents(ctx.resolver)
+    } = resolveVuetifyComponents(ctx.resolver, ctx.vuetifyBase)
     ctx.componentsPromise = componentsPromise
     ctx.labComponentsPromise = labComponentsPromise
   }
@@ -51,7 +51,7 @@ export async function load (
 
   if (dateOptions) {
     const adapter = dateOptions.adapter
-    const date = detectDate()
+    const date = detectDate(ctx.resolvePaths)
     if (!adapter && date.length > 1) {
       throw new Error(`Multiple date adapters found: ${date.map(d => `@date-io/${d[0]}`).join(', ')}, please specify the adapter to use in the "vuetifyOptions.date.adapter" option.`)
     }
@@ -85,7 +85,7 @@ export async function load (
   ctx.enableRules = ctx.moduleOptions.enableRules
   ctx.rulesConfiguration = ctx.moduleOptions.rulesConfiguration
   ctx.vuetifyFilesToWatch = Array.from(vuetifyConfigurationFilesToWatch)
-  ctx.icons = prepareIcons(ctx.unocss, ctx.logger, vuetifyAppOptions)
+  ctx.icons = prepareIcons(ctx.unocss, ctx.logger, vuetifyAppOptions, ctx.resolvePaths)
   ctx.ssrClientHints = prepareSSRClientHints(nuxt.options.app.baseURL ?? '/', ctx)
 
   if (ctx.icons.enabled) {

--- a/packages/vuetify-nuxt-module/src/utils/module.ts
+++ b/packages/vuetify-nuxt-module/src/utils/module.ts
@@ -2,7 +2,6 @@ import type { Resolver } from '@nuxt/kit'
 import type { ViteConfig } from '@nuxt/schema'
 import type { DateAdapter, VOptions } from '../types'
 import { readFile } from 'node:fs/promises'
-import { resolveVuetifyBase } from '@vuetify/loader-shared'
 import { isPackageExists } from 'local-pkg'
 
 export interface VuetifyImportMap {
@@ -10,7 +9,7 @@ export interface VuetifyImportMap {
 }
 export type VuetifyComponentsImportMap = Record<string, VuetifyImportMap>
 
-export function detectDate () {
+export function detectDate (paths: string[]) {
   const result: DateAdapter[] = []
 
   for (const adapter of [
@@ -23,7 +22,7 @@ export function detectDate () {
     'jalaali',
     'hijri',
   ]) {
-    if (isPackageExists(`@date-io/${adapter}`)) {
+    if (isPackageExists(`@date-io/${adapter}`, { paths })) {
       result.push(adapter as DateAdapter)
     }
   }
@@ -56,13 +55,11 @@ export function checkVuetifyPlugins (config: ViteConfig) {
   }
 }
 
-export function resolveVuetifyComponents (resolver: Resolver) {
-  const vuetifyBase = resolveVuetifyBase()
+export function resolveVuetifyComponents (resolver: Resolver, vuetifyBase: string) {
   const componentsPromise = importMapResolver()
   const labComponentsPromise = importMapLabResolver()
 
   return {
-    vuetifyBase,
     componentsPromise,
     labComponentsPromise,
   }


### PR DESCRIPTION
## Problem

Module setup resolved Vuetify via `@vuetify/loader-shared`'s `resolveVuetifyBase()`, which hardcodes:

```js
require.resolve('vuetify/package.json', { paths: [process.cwd()] })
```

This throws `Cannot find module 'vuetify/package.json'` whenever `vuetify` isn't reachable from the project **cwd** — i.e. pnpm isolated installs (where `vuetify` is only the module's own dependency, not a direct app dep) and Nuxt **layers** (especially external/remote layers with their own `node_modules`).

On Nuxt 3.16 this was a hard crash (#306). On current Nuxt it's *worse*: the module setup error is swallowed, so Vuetify **silently fails to set up** (no components/styles) with no error in the log.

The same `process.cwd()`-based detection (`isPackageExists`) silently disabled **date adapters**, **icon packs** and **`sass-embedded`** under the same layouts. The version probe (`getPackageInfo('vuetify')`) also degraded to `'0.0.0'`.

## Fix

- Resolve `vuetify/package.json` via Nuxt's `findPath` (honours `rootDir` + `modulesDir`, incl. layers), falling back to the module's **own** dependency through `import.meta.resolve` — Vuetify lives next to the module in the (pnpm) virtual store and is reachable even from external layers. Mirrors the approach in `@vuetify/unplugin-styles` and [nuxt/content#3791](https://github.com/nuxt/content/pull/3791).
- Pass the project resolution paths (`rootDir` + `modulesDir`) to `isPackageExists` for date adapters / icon packs / `sass-embedded`.
- Drop the now-unused `resolveVuetifyBase` and `isObject` imports from `@vuetify/loader-shared` (still used for `generateImports`).
- A clear error is thrown if Vuetify genuinely can't be resolved.

## Verification

- ✅ Existing suite: **27/27** (incl. `layers`, `sass`, `unplugin-styles`, `vuetify-config`).
- ✅ Real pnpm install matrix (module packed to a tarball, installed with different `node-linker`), before (main) vs after (fix):

  | layout | before | after |
  |---|---|---|
  | isolated, vuetify not a direct app dep (#306) | 🔴 setup fails | 🟢 |
  | hoisted | 🔴 (when vuetify not direct dep) | 🟢 |
  | local layers | 🔴 | 🟢 |
  | **external layer with its own `node_modules`** (vuetify only in the layer) (#277) | 🔴 `nuxi prepare` exit 1 | 🟢 |
  | isolated + date adapter + icon pack | — | 🟢 (detected) |

  In every "before" case the exact buggy call `require.resolve('vuetify/package.json', { paths: [process.cwd()] })` reproduces `MODULE_NOT_FOUND`.

Closes #277, #306