### PR TITLE
feat(ssr-client-hints): nested cookie config for color scheme

### DIFF
--- a/packages/vuetify-nuxt-module/configuration.d.ts
+++ b/packages/vuetify-nuxt-module/configuration.d.ts
@@ -36,6 +36,7 @@ declare module 'virtual:vuetify-ssr-client-hints-configuration' {
       defaultTheme: string
       themeNames: string[]
       cookieName: string
+      cookieDomain?: string
       darkThemeName: string
       lightThemeName: string
       useBrowserThemeOnly: boolean

--- a/packages/vuetify-nuxt-module/configuration.d.ts
+++ b/packages/vuetify-nuxt-module/configuration.d.ts
@@ -37,6 +37,8 @@ declare module 'virtual:vuetify-ssr-client-hints-configuration' {
       themeNames: string[]
       cookieName: string
       cookieDomain?: string
+      cookieSecure?: boolean
+      cookieSameSite: 'lax' | 'strict' | 'none'
       darkThemeName: string
       lightThemeName: string
       useBrowserThemeOnly: boolean

--- a/packages/vuetify-nuxt-module/src/runtime/plugins/vuetify-client-hints.client.ts
+++ b/packages/vuetify-nuxt-module/src/runtime/plugins/vuetify-client-hints.client.ts
@@ -154,15 +154,20 @@ function useSSRClientHints () {
     baseUrl,
     cookieName,
     cookieDomain,
+    cookieSecure,
+    cookieSameSite,
     defaultTheme,
   } = ssrClientHintsConfiguration.prefersColorSchemeOptions
   const cookieNamePrefix = `${cookieName}=`
   initial.value.colorSchemeFromCookie = document.cookie?.split(';')?.find(c => c.trim().startsWith(cookieNamePrefix))?.split('=')[1] ?? defaultTheme
   const date = new Date()
   const expires = new Date(date.setDate(date.getDate() + 365))
-  initial.value.colorSchemeCookie = `${cookieName}=${initial.value.colorSchemeFromCookie}; Path=${baseUrl}; Expires=${expires.toUTCString()}; SameSite=Lax`
+  initial.value.colorSchemeCookie = `${cookieName}=${initial.value.colorSchemeFromCookie}; Path=${baseUrl}; Expires=${expires.toUTCString()}; SameSite=${cookieSameSite[0].toUpperCase()}${cookieSameSite.slice(1)}`
   if (cookieDomain) {
     initial.value.colorSchemeCookie += `; Domain=${cookieDomain}`
+  }
+  if (cookieSecure) {
+    initial.value.colorSchemeCookie += '; Secure'
   }
 
   return initial

--- a/packages/vuetify-nuxt-module/src/runtime/plugins/vuetify-client-hints.client.ts
+++ b/packages/vuetify-nuxt-module/src/runtime/plugins/vuetify-client-hints.client.ts
@@ -153,6 +153,7 @@ function useSSRClientHints () {
   const {
     baseUrl,
     cookieName,
+    cookieDomain,
     defaultTheme,
   } = ssrClientHintsConfiguration.prefersColorSchemeOptions
   const cookieNamePrefix = `${cookieName}=`
@@ -160,6 +161,9 @@ function useSSRClientHints () {
   const date = new Date()
   const expires = new Date(date.setDate(date.getDate() + 365))
   initial.value.colorSchemeCookie = `${cookieName}=${initial.value.colorSchemeFromCookie}; Path=${baseUrl}; Expires=${expires.toUTCString()}; SameSite=Lax`
+  if (cookieDomain) {
+    initial.value.colorSchemeCookie += `; Domain=${cookieDomain}`
+  }
 
   return initial
 }

--- a/packages/vuetify-nuxt-module/src/runtime/plugins/vuetify-client-hints.server.ts
+++ b/packages/vuetify-nuxt-module/src/runtime/plugins/vuetify-client-hints.server.ts
@@ -365,6 +365,8 @@ function writeThemeCookie (
   const themeName = clientHintsRequest.colorSchemeFromCookie ?? ssrClientHintsConfiguration.prefersColorSchemeOptions.defaultTheme
   const path = ssrClientHintsConfiguration.prefersColorSchemeOptions.baseUrl
   const domain = ssrClientHintsConfiguration.prefersColorSchemeOptions.cookieDomain
+  const secure = ssrClientHintsConfiguration.prefersColorSchemeOptions.cookieSecure
+  const sameSite = ssrClientHintsConfiguration.prefersColorSchemeOptions.cookieSameSite
 
   const date = new Date()
   const expires = new Date(date.setDate(date.getDate() + 365))
@@ -373,13 +375,17 @@ function writeThemeCookie (
       path,
       domain,
       expires,
-      sameSite: 'lax',
+      sameSite,
+      secure,
     }).value = themeName
   }
 
-  let cookie = `${cookieName}=${themeName}; Path=${path}; Expires=${expires.toUTCString()}; SameSite=Lax`
+  let cookie = `${cookieName}=${themeName}; Path=${path}; Expires=${expires.toUTCString()}; SameSite=${sameSite[0].toUpperCase()}${sameSite.slice(1)}`
   if (domain) {
     cookie += `; Domain=${domain}`
+  }
+  if (secure) {
+    cookie += '; Secure'
   }
 
   return cookie

--- a/packages/vuetify-nuxt-module/src/runtime/plugins/vuetify-client-hints.server.ts
+++ b/packages/vuetify-nuxt-module/src/runtime/plugins/vuetify-client-hints.server.ts
@@ -364,18 +364,25 @@ function writeThemeCookie (
   const cookieName = ssrClientHintsConfiguration.prefersColorSchemeOptions.cookieName
   const themeName = clientHintsRequest.colorSchemeFromCookie ?? ssrClientHintsConfiguration.prefersColorSchemeOptions.defaultTheme
   const path = ssrClientHintsConfiguration.prefersColorSchemeOptions.baseUrl
+  const domain = ssrClientHintsConfiguration.prefersColorSchemeOptions.cookieDomain
 
   const date = new Date()
   const expires = new Date(date.setDate(date.getDate() + 365))
   if (!clientHintsRequest.firstRequest || !ssrClientHintsConfiguration.reloadOnFirstRequest) {
     useCookie(cookieName, {
       path,
+      domain,
       expires,
       sameSite: 'lax',
     }).value = themeName
   }
 
-  return `${cookieName}=${themeName}; Path=${path}; Expires=${expires.toUTCString()}; SameSite=Lax`
+  let cookie = `${cookieName}=${themeName}; Path=${path}; Expires=${expires.toUTCString()}; SameSite=Lax`
+  if (domain) {
+    cookie += `; Domain=${domain}`
+  }
+
+  return cookie
 }
 
 export default plugin

--- a/packages/vuetify-nuxt-module/src/types.ts
+++ b/packages/vuetify-nuxt-module/src/types.ts
@@ -366,17 +366,43 @@ export interface MOptions {
       /**
        * The name for the cookie.
        *
+       * @deprecated Use `cookie.name` instead.
        * @default 'color-scheme'
        */
       cookieName?: string
       /**
-       * The domain for the color scheme cookie.
-       *
-       * Useful to share the cookie across subdomains, e.g. `.example.com`.
-       *
-       * @default undefined
+       * Cookie attributes for the color scheme cookie.
        */
-      cookieDomain?: string
+      cookie?: {
+        /**
+         * The name for the cookie.
+         *
+         * @default 'color-scheme'
+         */
+        name?: string
+        /**
+         * The domain for the color scheme cookie.
+         *
+         * Useful to share the cookie across subdomains, e.g. `.example.com`.
+         *
+         * @default undefined
+         */
+        domain?: string
+        /**
+         * Mark the cookie as `Secure`.
+         *
+         * Forced to `true` when `sameSite` is `'none'`.
+         *
+         * @default undefined
+         */
+        secure?: boolean
+        /**
+         * The `SameSite` attribute for the cookie.
+         *
+         * @default 'lax'
+         */
+        sameSite?: 'lax' | 'strict' | 'none'
+      }
       /**
        * The name for the dark theme.
        *
@@ -477,6 +503,8 @@ export interface SSRClientHintsConfiguration {
     themeNames: string[]
     cookieName: string
     cookieDomain?: string
+    cookieSecure?: boolean
+    cookieSameSite: 'lax' | 'strict' | 'none'
     darkThemeName: string
     lightThemeName: string
   }

--- a/packages/vuetify-nuxt-module/src/types.ts
+++ b/packages/vuetify-nuxt-module/src/types.ts
@@ -370,6 +370,14 @@ export interface MOptions {
        */
       cookieName?: string
       /**
+       * The domain for the color scheme cookie.
+       *
+       * Useful to share the cookie across subdomains, e.g. `.example.com`.
+       *
+       * @default undefined
+       */
+      cookieDomain?: string
+      /**
        * The name for the dark theme.
        *
        * @default 'dark'
@@ -468,6 +476,7 @@ export interface SSRClientHintsConfiguration {
     defaultTheme: string
     themeNames: string[]
     cookieName: string
+    cookieDomain?: string
     darkThemeName: string
     lightThemeName: string
   }

--- a/packages/vuetify-nuxt-module/src/utils/ssr-client-hints.ts
+++ b/packages/vuetify-nuxt-module/src/utils/ssr-client-hints.ts
@@ -11,6 +11,7 @@ export interface ResolvedClientHints {
     defaultTheme: string
     themeNames: string[]
     cookieName: string
+    cookieDomain?: string
     darkThemeName: string
     lightThemeName: string
     useBrowserThemeOnly: boolean
@@ -81,6 +82,7 @@ export function prepareSSRClientHints (baseUrl: string, ctx: VuetifyNuxtContext)
       defaultTheme,
       themeNames: Array.from(Object.keys(themes)),
       cookieName: ssrClientHintsConfiguration.prefersColorSchemeOptions?.cookieName ?? 'color-scheme',
+      cookieDomain: ssrClientHintsConfiguration.prefersColorSchemeOptions.cookieDomain,
       darkThemeName,
       lightThemeName,
       useBrowserThemeOnly: ssrClientHintsConfiguration.prefersColorSchemeOptions?.useBrowserThemeOnly ?? false,

--- a/packages/vuetify-nuxt-module/src/utils/ssr-client-hints.ts
+++ b/packages/vuetify-nuxt-module/src/utils/ssr-client-hints.ts
@@ -12,6 +12,8 @@ export interface ResolvedClientHints {
     themeNames: string[]
     cookieName: string
     cookieDomain?: string
+    cookieSecure?: boolean
+    cookieSameSite: 'lax' | 'strict' | 'none'
     darkThemeName: string
     lightThemeName: string
     useBrowserThemeOnly: boolean

--- a/packages/vuetify-nuxt-module/src/utils/ssr-client-hints.ts
+++ b/packages/vuetify-nuxt-module/src/utils/ssr-client-hints.ts
@@ -28,6 +28,23 @@ const disabledClientHints: ResolvedClientHints = Object.freeze({
   prefersReducedMotion: false,
 })
 
+type PrefersColorSchemeInput = NonNullable<NonNullable<VuetifyNuxtContext['moduleOptions']['ssrClientHints']>['prefersColorSchemeOptions']>
+
+function resolveColorSchemeCookie (options: PrefersColorSchemeInput, logger: VuetifyNuxtContext['logger']) {
+  if (options.cookieName !== undefined) {
+    logger.warn('[vuetify-nuxt-module] `prefersColorSchemeOptions.cookieName` is deprecated, use `prefersColorSchemeOptions.cookie.name` instead.')
+  }
+
+  const cookieSameSite = options.cookie?.sameSite ?? 'lax'
+
+  return {
+    cookieName: options.cookie?.name ?? options.cookieName ?? 'color-scheme',
+    cookieDomain: options.cookie?.domain,
+    cookieSecure: cookieSameSite === 'none' ? true : options.cookie?.secure,
+    cookieSameSite,
+  }
+}
+
 export function prepareSSRClientHints (baseUrl: string, ctx: VuetifyNuxtContext) {
   if (!ctx.isSSR || ctx.isNuxtGenerate) {
     return disabledClientHints
@@ -80,21 +97,12 @@ export function prepareSSRClientHints (baseUrl: string, ctx: VuetifyNuxtContext)
     }
 
     const pcsOptions = ssrClientHintsConfiguration.prefersColorSchemeOptions
-    if (pcsOptions?.cookieName !== undefined) {
-      ctx.logger.warn('[vuetify-nuxt-module] `prefersColorSchemeOptions.cookieName` is deprecated, use `prefersColorSchemeOptions.cookie.name` instead.')
-    }
-
-    const cookieSameSite = pcsOptions?.cookie?.sameSite ?? 'lax'
-    const cookieSecure = cookieSameSite === 'none' ? true : pcsOptions?.cookie?.secure
 
     clientHints.prefersColorSchemeOptions = {
       baseUrl,
       defaultTheme,
       themeNames: Array.from(Object.keys(themes)),
-      cookieName: pcsOptions?.cookie?.name ?? pcsOptions?.cookieName ?? 'color-scheme',
-      cookieDomain: pcsOptions?.cookie?.domain,
-      cookieSecure,
-      cookieSameSite,
+      ...resolveColorSchemeCookie(pcsOptions, ctx.logger),
       darkThemeName,
       lightThemeName,
       useBrowserThemeOnly: pcsOptions?.useBrowserThemeOnly ?? false,

--- a/packages/vuetify-nuxt-module/src/utils/ssr-client-hints.ts
+++ b/packages/vuetify-nuxt-module/src/utils/ssr-client-hints.ts
@@ -79,15 +79,25 @@ export function prepareSSRClientHints (baseUrl: string, ctx: VuetifyNuxtContext)
       throw new Error('Vuetify dark theme and light theme are the same, change darkThemeName or lightThemeName!')
     }
 
+    const pcsOptions = ssrClientHintsConfiguration.prefersColorSchemeOptions
+    if (pcsOptions?.cookieName !== undefined) {
+      ctx.logger.warn('[vuetify-nuxt-module] `prefersColorSchemeOptions.cookieName` is deprecated, use `prefersColorSchemeOptions.cookie.name` instead.')
+    }
+
+    const cookieSameSite = pcsOptions?.cookie?.sameSite ?? 'lax'
+    const cookieSecure = cookieSameSite === 'none' ? true : pcsOptions?.cookie?.secure
+
     clientHints.prefersColorSchemeOptions = {
       baseUrl,
       defaultTheme,
       themeNames: Array.from(Object.keys(themes)),
-      cookieName: ssrClientHintsConfiguration.prefersColorSchemeOptions?.cookieName ?? 'color-scheme',
-      cookieDomain: ssrClientHintsConfiguration.prefersColorSchemeOptions.cookieDomain,
+      cookieName: pcsOptions?.cookie?.name ?? pcsOptions?.cookieName ?? 'color-scheme',
+      cookieDomain: pcsOptions?.cookie?.domain,
+      cookieSecure,
+      cookieSameSite,
       darkThemeName,
       lightThemeName,
-      useBrowserThemeOnly: ssrClientHintsConfiguration.prefersColorSchemeOptions?.useBrowserThemeOnly ?? false,
+      useBrowserThemeOnly: pcsOptions?.useBrowserThemeOnly ?? false,
     }
   }
 

--- a/packages/vuetify-nuxt-module/test/ssr-client-hints.test.ts
+++ b/packages/vuetify-nuxt-module/test/ssr-client-hints.test.ts
@@ -1,0 +1,73 @@
+import type { VuetifyNuxtContext } from '../src/utils/config'
+import { describe, expect, it, vi } from 'vitest'
+import { prepareSSRClientHints } from '../src/utils/ssr-client-hints'
+
+function createCtx (prefersColorSchemeOptions: any) {
+  const warn = vi.fn()
+  const ctx = {
+    isSSR: true,
+    isNuxtGenerate: false,
+    logger: { warn },
+    moduleOptions: {
+      ssrClientHints: {
+        prefersColorScheme: true,
+        prefersColorSchemeOptions,
+      },
+    },
+    vuetifyOptions: {
+      theme: {
+        defaultTheme: 'light',
+        themes: { light: {}, dark: {} },
+      },
+    },
+  } as unknown as VuetifyNuxtContext
+  return { ctx, warn }
+}
+
+describe('prepareSSRClientHints cookie normalisation', () => {
+  it('uses cookie.* fields when provided', () => {
+    const { ctx, warn } = createCtx({
+      cookie: { name: 'cs', domain: '.example.com', secure: true, sameSite: 'strict' },
+    })
+    const opts = prepareSSRClientHints('/', ctx).prefersColorSchemeOptions
+    expect(opts?.cookieName).toBe('cs')
+    expect(opts?.cookieDomain).toBe('.example.com')
+    expect(opts?.cookieSecure).toBe(true)
+    expect(opts?.cookieSameSite).toBe('strict')
+    expect(warn).not.toHaveBeenCalled()
+  })
+
+  it('maps the deprecated cookieName and warns once', () => {
+    const { ctx, warn } = createCtx({ cookieName: 'legacy' })
+    const opts = prepareSSRClientHints('/', ctx).prefersColorSchemeOptions
+    expect(opts?.cookieName).toBe('legacy')
+    expect(opts?.cookieSameSite).toBe('lax')
+    expect(opts?.cookieDomain).toBeUndefined()
+    expect(opts?.cookieSecure).toBeUndefined()
+    expect(warn).toHaveBeenCalledTimes(1)
+  })
+
+  it('prefers cookie.name over the deprecated cookieName', () => {
+    const { ctx, warn } = createCtx({ cookieName: 'legacy', cookie: { name: 'newname' } })
+    const opts = prepareSSRClientHints('/', ctx).prefersColorSchemeOptions
+    expect(opts?.cookieName).toBe('newname')
+    expect(warn).toHaveBeenCalledTimes(1)
+  })
+
+  it('applies defaults when nothing is set', () => {
+    const { ctx, warn } = createCtx({})
+    const opts = prepareSSRClientHints('/', ctx).prefersColorSchemeOptions
+    expect(opts?.cookieName).toBe('color-scheme')
+    expect(opts?.cookieSameSite).toBe('lax')
+    expect(opts?.cookieDomain).toBeUndefined()
+    expect(opts?.cookieSecure).toBeUndefined()
+    expect(warn).not.toHaveBeenCalled()
+  })
+
+  it('forces secure when sameSite is none', () => {
+    const { ctx } = createCtx({ cookie: { sameSite: 'none', secure: false } })
+    const opts = prepareSSRClientHints('/', ctx).prefersColorSchemeOptions
+    expect(opts?.cookieSameSite).toBe('none')
+    expect(opts?.cookieSecure).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary

Reshapes the color-scheme cookie configuration under `prefersColorSchemeOptions` into a nested `cookie: {}` object and adds control over `Secure`/`SameSite`.

- New `prefersColorSchemeOptions.cookie?: { name?, domain?, secure?, sameSite? }`.
- `cookieName` is kept but **deprecated** (maps to `cookie.name`; emits one build-time warning when used). When both are set, `cookie.name` wins.
- The previously proposed flat `cookieDomain` option is **removed** — use `cookie.domain`.
- `secure` and `sameSite` were previously hardcoded (`SameSite=Lax`, no `Secure`); they are now configurable. `secure` is forced to `true` when `sameSite` is `'none'`.

Default behaviour is unchanged: `cookie.name` defaults to `color-scheme`, `SameSite=Lax`, no `Secure`, no `Domain`.

```ts
ssrClientHints: {
  prefersColorScheme: true,
  prefersColorSchemeOptions: {
    cookie: {
      name: 'color-scheme',
      domain: '.example.com',
      sameSite: 'lax',
      // secure: true,
    },
  },
}
```

## Implementation notes

- Public input gains the nested `cookie` object; the resolved/runtime config stays flat (`cookieName`, `cookieDomain`, `cookieSecure`, `cookieSameSite`) to keep the runtime plugins simple.
- Normalisation (legacy + nested → flat) lives in `prepareSSRClientHints`, extracted into a small `resolveColorSchemeCookie` helper.

## Test Plan

- [x] Unit tests for `prepareSSRClientHints` normalisation: nested-only, legacy-only (warns), both (new wins), defaults, `sameSite:'none'` forces `secure`.
- [x] Full unit suite (32 tests) passing.
- [x] Lint clean; module + playground typecheck (`dev:prepare`) clean.