### PR TITLE
fix(ssr): guard Vuetify 4 `theme: 'system'` under SSR

### DIFF
--- a/docs/guide/features/ssr.md
+++ b/docs/guide/features/ssr.md
@@ -98,6 +98,37 @@ const { isDark } = useCustomTheme()
 </template>
 ```
 
+### Vuetify `system` theme and SSR
+
+::: warning
+Vuetify 4 resolves `defaultTheme: 'system'` only in the browser (via `window.matchMedia`), so it is **not** SSR/SSG-safe: the server has no access to the OS color-scheme preference, so the first paint defaults to `light` and may flash on dark systems.
+
+To avoid the flash, set explicit `dark`/`light` themes and enable `ssrClientHints.prefersColorScheme` (optionally `prefersColorSchemeOptions.useBrowserThemeOnly`) so the browser preference is restored after the first request:
+
+```ts [nuxt.config.ts]
+export default defineNuxtConfig({
+  modules: ['vuetify-nuxt-module'],
+  vuetify: {
+    moduleOptions: {
+      ssrClientHints: {
+        prefersColorScheme: true,
+        prefersColorSchemeOptions: {
+          useBrowserThemeOnly: true,
+        },
+      },
+    },
+    vuetifyOptions: {
+      theme: {
+        defaultTheme: 'light',
+      },
+    },
+  },
+})
+```
+
+Full server-side resolution of the `system` theme is tracked for a future major release.
+:::
+
 ## Vuetify Display
 
 If you're using Vuetify [useDisplay](https://vuetifyjs.com/en/api/use-display/) composable with SSR enabled, there is only one way for the server to get the client's width and height (still in draft): use the [Sec-CH-Viewport-Width](https://wicg.github.io/responsive-image-client-hints/#sec-ch-viewport-width) and [Sec-CH-Viewport-Height](https://wicg.github.io/responsive-image-client-hints/#sec-ch-viewport-height) headers respectively, will not work for the initial request.

--- a/packages/vuetify-nuxt-module/src/utils/loader.ts
+++ b/packages/vuetify-nuxt-module/src/utils/loader.ts
@@ -88,6 +88,16 @@ export async function load (
   ctx.icons = prepareIcons(ctx.unocss, ctx.logger, vuetifyAppOptions, ctx.resolvePaths)
   ctx.ssrClientHints = prepareSSRClientHints(nuxt.options.app.baseURL ?? '/', ctx)
 
+  if (
+    ctx.isSSR
+    && !ctx.ssrClientHints.prefersColorScheme
+    && ctx.vuetifyOptions.theme
+    && typeof ctx.vuetifyOptions.theme === 'object'
+    && ctx.vuetifyOptions.theme.defaultTheme === 'system'
+  ) {
+    ctx.logger.warn('`theme.defaultTheme: "system"` cannot be resolved during SSR/SSG: the server has no access to the OS color-scheme preference, so the first paint defaults to light and may flash on dark systems. Set explicit dark/light themes and enable `moduleOptions.ssrClientHints.prefersColorScheme` (optionally `prefersColorSchemeOptions.useBrowserThemeOnly`). See the SSR guide.')
+  }
+
   if (ctx.icons.enabled) {
     if (ctx.icons.local) {
       for (const css of ctx.icons.local) {

--- a/packages/vuetify-nuxt-module/src/utils/ssr-client-hints.ts
+++ b/packages/vuetify-nuxt-module/src/utils/ssr-client-hints.ts
@@ -45,6 +45,28 @@ function resolveColorSchemeCookie (options: PrefersColorSchemeInput, logger: Vue
   }
 }
 
+function resolveDefaultTheme (
+  defaultTheme: string,
+  themes: Record<string, unknown>,
+  lightThemeName: string,
+  logger: VuetifyNuxtContext['logger'],
+) {
+  // Vuetify 4 resolves `defaultTheme: 'system'` only in the browser (via `window.matchMedia`),
+  // so it cannot be resolved during SSR/SSG. Fall back to the configured light theme on the
+  // server (matching Vuetify's own `systemName` initial value of `'light'`); the browser
+  // preference is applied on the client via prefersColorScheme client hints.
+  if (defaultTheme === 'system') {
+    logger.warn(`Vuetify "system" theme cannot be resolved during SSR; using "${lightThemeName}" as the server-side fallback. The browser preference is applied on the client via prefersColorScheme client hints. To avoid a flash of the wrong theme, set explicit dark/light themes and enable moduleOptions.ssrClientHints.prefersColorSchemeOptions.useBrowserThemeOnly.`)
+    return lightThemeName
+  }
+
+  if (!themes[defaultTheme]) {
+    throw new Error(`Missing default theme ${defaultTheme} in the Vuetify themes!`)
+  }
+
+  return defaultTheme
+}
+
 export function prepareSSRClientHints (baseUrl: string, ctx: VuetifyNuxtContext) {
   if (!ctx.isSSR || ctx.isNuxtGenerate) {
     return disabledClientHints
@@ -78,10 +100,6 @@ export function prepareSSRClientHints (baseUrl: string, ctx: VuetifyNuxtContext)
       throw new Error('Vuetify default theme is missing in theme!')
     }
 
-    if (!themes[defaultTheme]) {
-      throw new Error(`Missing default theme ${defaultTheme} in the Vuetify themes!`)
-    }
-
     const darkThemeName = ssrClientHintsConfiguration.prefersColorSchemeOptions?.darkThemeName ?? 'dark'
     if (!themes[darkThemeName]) {
       throw new Error(`Missing theme ${darkThemeName} in the Vuetify themes!`)
@@ -97,10 +115,11 @@ export function prepareSSRClientHints (baseUrl: string, ctx: VuetifyNuxtContext)
     }
 
     const pcsOptions = ssrClientHintsConfiguration.prefersColorSchemeOptions
+    const effectiveDefaultTheme = resolveDefaultTheme(defaultTheme, themes, lightThemeName, ctx.logger)
 
     clientHints.prefersColorSchemeOptions = {
       baseUrl,
-      defaultTheme,
+      defaultTheme: effectiveDefaultTheme,
       themeNames: Array.from(Object.keys(themes)),
       ...resolveColorSchemeCookie(pcsOptions, ctx.logger),
       darkThemeName,


### PR DESCRIPTION
## Problem

In Vuetify 4, `defaultTheme: 'system'` resolves the OS preference **only client-side** via `window.matchMedia` (guarded by `SUPPORTS_MATCH_MEDIA`, which is `false` on the server). During SSR/SSG the server therefore defaults to `light` and may flash on dark systems. This surfaces as two failure modes in this module:

- **Mode #1 (no client hints):** the module passes `theme.defaultTheme: 'system'` through to Vuetify untouched, producing a flash of the wrong theme on dark systems.
- **Mode #2 (client hints on):** `src/utils/ssr-client-hints.ts` throws `Missing default theme system in the Vuetify themes!` because `'system'` is not a real theme entry — the module's own SSR theme handling crashes the moment it meets Vuetify 4's default.

## What this PR does

This is a small, safe guard. It does **not** attempt to make `system` resolve server-side.

1. **Stops the crash (Mode #2):** when `prefersColorScheme` client hints are enabled and `defaultTheme === 'system'`, the module no longer throws. It falls back to the configured light theme on the server (matching Vuetify's own `systemName` initial value of `'light'`), and the browser preference is still applied on the client via prefersColorScheme client hints. The `'system'` resolution was extracted into a small `resolveDefaultTheme` helper to stay under the repo's ESLint `complexity` cap.
2. **Warns developers (Mode #1):** when `defaultTheme: 'system'` is used under SSR and client hints will not handle it, the module emits a dev warning explaining the limitation and the recommended configuration. The warnings are mutually exclusive, so a project never gets double-warned.
3. **Documents the limitation:** adds a "Vuetify `system` theme and SSR" note to `docs/guide/features/ssr.md` with the recommended explicit-themes + client-hints configuration.

## Out of scope

Full server-side resolution of the `system` theme is intentionally deferred to the upcoming major (2.0.0) rewrite.

Refs #325, #362
