### PR TITLE
fix(date): use full adapter name in multiple-adapters error message

### DIFF
--- a/packages/vuetify-nuxt-module/src/utils/loader.ts
+++ b/packages/vuetify-nuxt-module/src/utils/loader.ts
@@ -9,7 +9,7 @@ import { debounce } from 'perfect-debounce'
 import { RESOLVED_VIRTUAL_MODULES } from '../vite/constants'
 import { prepareIcons } from './icons'
 import { mergeVuetifyModules } from './layers'
-import { cleanupBlueprint, detectDate, resolveVuetifyComponents } from './module'
+import { cleanupBlueprint, detectDate, multipleDateAdaptersError, resolveVuetifyComponents } from './module'
 import { prepareSSRClientHints } from './ssr-client-hints'
 
 export async function load (
@@ -53,7 +53,7 @@ export async function load (
     const adapter = dateOptions.adapter
     const date = detectDate()
     if (!adapter && date.length > 1) {
-      throw new Error(`Multiple date adapters found: ${date.map(d => `@date-io/${d}`).join(', ')}, please specify the adapter to use in the "vuetifyOptions.date.adapter" option.`)
+      throw new Error(multipleDateAdaptersError(date))
     }
 
     if (adapter) {

--- a/packages/vuetify-nuxt-module/src/utils/loader.ts
+++ b/packages/vuetify-nuxt-module/src/utils/loader.ts
@@ -53,7 +53,7 @@ export async function load (
     const adapter = dateOptions.adapter
     const date = detectDate()
     if (!adapter && date.length > 1) {
-      throw new Error(`Multiple date adapters found: ${date.map(d => `@date-io/${d[0]}`).join(', ')}, please specify the adapter to use in the "vuetifyOptions.date.adapter" option.`)
+      throw new Error(`Multiple date adapters found: ${date.map(d => `@date-io/${d}`).join(', ')}, please specify the adapter to use in the "vuetifyOptions.date.adapter" option.`)
     }
 
     if (adapter) {

--- a/packages/vuetify-nuxt-module/src/utils/module.ts
+++ b/packages/vuetify-nuxt-module/src/utils/module.ts
@@ -31,6 +31,10 @@ export function detectDate () {
   return result
 }
 
+export function multipleDateAdaptersError (adapters: DateAdapter[]) {
+  return `Multiple date adapters found: ${adapters.map(adapter => `@date-io/${adapter}`).join(', ')}, please specify the adapter to use in the "vuetifyOptions.date.adapter" option.`
+}
+
 export function cleanupBlueprint (vuetifyOptions: VOptions) {
   const blueprint = vuetifyOptions.blueprint
   if (blueprint) {

--- a/packages/vuetify-nuxt-module/test/date-adapters.test.ts
+++ b/packages/vuetify-nuxt-module/test/date-adapters.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest'
+import { multipleDateAdaptersError } from '../src/utils/module'
+
+describe('multipleDateAdaptersError', () => {
+  it('lists the full @date-io adapter names', () => {
+    const message = multipleDateAdaptersError(['date-fns', 'luxon'])
+    expect(message).toContain('@date-io/date-fns, @date-io/luxon')
+    expect(message).not.toContain('@date-io/d, @date-io/l')
+  })
+
+  it('keeps the guidance about specifying the adapter option', () => {
+    const message = multipleDateAdaptersError(['moment', 'dayjs'])
+    expect(message).toBe('Multiple date adapters found: @date-io/moment, @date-io/dayjs, please specify the adapter to use in the "vuetifyOptions.date.adapter" option.')
+  })
+})


### PR DESCRIPTION
## Summary

When multiple date adapters are detected and none is configured, the thrown error built the adapter list with `d[0]` — the first character of each adapter name — instead of the full name. `detectDate()` returns full name strings (e.g. `date-fns`, `luxon`), so the message read:

> Multiple date adapters found: @date-io/d, @date-io/l, ...

instead of:

> Multiple date adapters found: @date-io/date-fns, @date-io/luxon, ...

Fixed by interpolating `d` instead of `d[0]`.

## Test Plan

- [x] Lint clean.
- Message-only fix; reproduced by installing two `@date-io/*` adapters without setting `vuetifyOptions.date.adapter`.