### PR TITLE
feat(labs): clearer warning for graduated labComponents

### DIFF
--- a/packages/vuetify-nuxt-module/src/vite/vuetify-configuration-plugin.ts
+++ b/packages/vuetify-nuxt-module/src/vite/vuetify-configuration-plugin.ts
@@ -212,11 +212,16 @@ async function buildConfiguration (ctx: VuetifyNuxtContext) {
     if (useLabComponents.length > 0) {
       componentsToImport.clear()
       const importMapLabComponents = await labComponentsPromise
+      const importMapStableComponents = await componentsPromise
       for (const component of useLabComponents) {
         const componentEntry = importMapLabComponents[component]
         const from = componentEntry?.from
         if (!from) {
-          logger.warn(`Lab Component ${component} not found in Vuetify.`)
+          if (importMapStableComponents[component]) {
+            logger.warn(`Lab component "${component}" has graduated to stable in your Vuetify version and is no longer under vuetify/labs. Remove it from "labComponents" — it is auto-imported on demand like any stable component.`)
+          } else {
+            logger.warn(`Lab Component ${component} not found in Vuetify.`)
+          }
           continue
         }
 


### PR DESCRIPTION
## Problem

After Vuetify 4.1, several components graduated from `vuetify/labs` to stable (e.g. `VFileUpload`). Users who upgrade but keep a graduated component listed in their `labComponents` option saw a misleading warning:

```
Lab Component VFileUpload not found in Vuetify.
```

This is confusing — the component very much exists; it just moved out of labs and is now auto-imported on demand like any other stable component.

## Change

In `buildConfiguration` (vite/vuetify-configuration-plugin.ts), when a `labComponents` entry is not found in the labs importMap, we now also check the stable component importMap (`componentsPromise`, already available on the context):

- If the component exists in the stable map, it graduated. We emit a clear, actionable warning telling the user to remove it from `labComponents` (it is auto-imported anyway).
- Otherwise we keep the existing `not found in Vuetify` message for genuinely unknown names.

Registration/import behavior is unchanged — graduated components continue to be auto-imported elsewhere by vite-plugin-vuetify; this only fixes the message.

## Verification

- ESLint on the changed file: pass (exit 0)
- `pnpm -C packages/vuetify-nuxt-module run prepack`: pass
- Playground build with `labComponents: ['VFileUpload']` (graduated): build succeeds and the new graduated-specific warning fires.
- Playground build with `labComponents: ['VNotAComponent123']` (bogus): build succeeds and the original `not found in Vuetify` message still fires.

## Note

This stacks on #369 (which bumps the catalog to vuetify ^4.1.1, where `VFileUpload` is stable) and should merge after it. Base branch is `chore/vuetify-4.1`.