### PR TITLE
fix(i18n): expose numericGroupSeparator from locale adapter (#372)

### DIFF
--- a/packages/vuetify-nuxt-module/src/runtime/plugins/i18n.ts
+++ b/packages/vuetify-nuxt-module/src/runtime/plugins/i18n.ts
@@ -9,6 +9,14 @@ function inferDecimalSeparator (n: ReturnType<typeof useI18n>['n']) {
   return n(0.1).includes(',') ? ',' : '.'
 }
 
+function inferNumericGroupSeparator (n: ReturnType<typeof useI18n>['n']) {
+  // Vuetify's own adapter uses `n(10000, { part: true }).find(...)`, but vue-i18n's
+  // `n` does not honour `part` in every Nuxt i18n setup (it returns a string, not
+  // parts), so derive the separator from the grouped output instead — same string
+  // approach as inferDecimalSeparator above.
+  return n(10_000, { useGrouping: true }).replace(/\p{Nd}/gu, '') || ' '
+}
+
 export function createAdapter (vuetifyOptions: VuetifyOptions) {
   vuetifyOptions.locale = {}
   const nuxtApp = useNuxtApp()
@@ -42,6 +50,7 @@ export function createAdapter (vuetifyOptions: VuetifyOptions) {
     n: i18n.n,
     provide: createProvideFunction({ current: currentLocale, fallback, messages }),
     decimalSeparator: toRef(() => inferDecimalSeparator(i18n.n)),
+    numericGroupSeparator: toRef(() => inferNumericGroupSeparator(i18n.n)),
   }
 }
 
@@ -81,6 +90,7 @@ function createProvideFunction (data: {
       t,
       n,
       decimalSeparator: toRef(() => props.decimalSeparator ?? inferDecimalSeparator(n)),
+      numericGroupSeparator: toRef(() => inferNumericGroupSeparator(n)),
       provide: createProvideFunction({ current: currentLocale, fallback: data.fallback, messages: data.messages }),
     }
   }


### PR DESCRIPTION
Closes #372

## Problem

Vuetify **4.1.0** made `VNumberInput` read `numericGroupSeparator` from the locale adapter:

```js
// vuetify/lib/components/VNumberInput/VNumberInput.js
const { numericGroupSeparator: numericGroupSeparatorFromLocale } = useLocale()
const groupSeparator = computed(() => props.groupSeparator?.[0] || numericGroupSeparatorFromLocale.value)
```

The module's custom `nuxt-vue-i18n` adapter only exposed `decimalSeparator`, so `numericGroupSeparator` was `undefined`. Any `<VNumberInput>` rendered without an explicit `group-separator` prop crashed with:

```
Cannot read properties of undefined (reading 'value')
```

**Affected:** `vuetify-nuxt-module` with `@nuxtjs/i18n` enabled, on `vuetify >= 4.1.0`. The current dependency range (`^4.0.1`) already resolves to 4.1.x for consumers, so this reproduces on the released beta. The non-i18n path is unaffected — Vuetify's built-in locale adapter provides `numericGroupSeparator` natively.

## Fix

Expose `numericGroupSeparator` from both the root adapter and the per-component `provide` function in `runtime/plugins/i18n.ts`.

Vuetify's own vue-i18n adapter infers it via `n(10000, { part: true }).find(...)`, but vue-i18n's `n` does **not** honour `part` in the Nuxt setup (the global `$i18n.n` returns a formatted string, not `Intl.NumberFormatPart[]`), which would throw `n(...).find is not a function`. So the separator is derived from the grouped output string — the same approach as the existing `inferDecimalSeparator`:

```ts
function inferNumericGroupSeparator (n) {
  return n(10_000, { useGrouping: true }).replace(/\p{Nd}/gu, '') || ' '
}
```

## Verification

- Reproduced on vuetify@4.1.1: SSR `<v-number-input>` → HTTP 500 with the documented crash.
- After the fix: HTTP 200, component renders.
- Confirmed the bug starts at 4.1.0 (4.0.1's `VNumberInput` does not read the field).
- `pnpm lint` clean; full test suite (34 tests) green.