### PR TITLE
fix(config): make module defaults overridable by vuetify:registerModule hooks & layers (#290)

### DIFF
--- a/packages/vuetify-nuxt-module/src/module.ts
+++ b/packages/vuetify-nuxt-module/src/module.ts
@@ -93,24 +93,6 @@ export default defineNuxtModule<ModuleOptions>({
     version,
   },
   /**
-   * Default configuration options of the Nuxt module
-   */
-  defaults: () => ({
-    vuetifyOptions: {
-      labComponents: false,
-      directives: false,
-    },
-    moduleOptions: {
-      importComposables: true,
-      includeTransformAssetsUrls: true,
-      styles: true,
-      disableVuetifyStyles: false,
-      rulesConfiguration: {
-        fromLabs: true,
-      },
-    },
-  }),
-  /**
    * Sets up the Vuetify Nuxt module.
    *
    * @param options - The module options.

--- a/packages/vuetify-nuxt-module/src/utils/layers.ts
+++ b/packages/vuetify-nuxt-module/src/utils/layers.ts
@@ -13,7 +13,6 @@ export const MODULE_DEFAULTS: InlineModuleOptions = {
     importComposables: true,
     includeTransformAssetsUrls: true,
     styles: true,
-    disableVuetifyStyles: false,
     rulesConfiguration: {
       fromLabs: true,
     },

--- a/packages/vuetify-nuxt-module/src/utils/layers.ts
+++ b/packages/vuetify-nuxt-module/src/utils/layers.ts
@@ -4,6 +4,43 @@ import defu from 'defu'
 import { loadVuetifyConfiguration } from './config'
 
 /**
+ * Module defaults — applied as the LOWEST-priority `defu` argument so that
+ * `vuetify:registerModule` hooks and layers can override them, while the app's
+ * explicit `nuxt.config` values (the defu base) still win (#290).
+ */
+export const MODULE_DEFAULTS: InlineModuleOptions = {
+  moduleOptions: {
+    importComposables: true,
+    includeTransformAssetsUrls: true,
+    styles: true,
+    disableVuetifyStyles: false,
+    rulesConfiguration: {
+      fromLabs: true,
+    },
+  },
+  vuetifyOptions: {
+    labComponents: false,
+    directives: false,
+  },
+}
+
+/**
+ * Merge collected configuration entries — `[app, ...hooks, ...layers]` — applying
+ * MODULE_DEFAULTS last. `app` is the defu base (#231); ordering is not reversed (#218);
+ * icons `sets` are deduped across entries (#214/#217).
+ */
+export function finalizeConfiguration (moduleOptions: InlineModuleOptions[]): InlineModuleOptions {
+  if (moduleOptions.length > 1) {
+    const [app, ...rest] = moduleOptions
+    const configuration = <InlineModuleOptions>defu(app, ...rest, MODULE_DEFAULTS)
+    // dedupe icons sets: fix #214 and #217 — reverse so the last (app) wins
+    dedupeIcons(configuration, moduleOptions.toReversed())
+    return configuration
+  }
+  return <InlineModuleOptions>defu(moduleOptions[0] ?? {}, MODULE_DEFAULTS)
+}
+
+/**
  * Merges project layer with registered vuetify modules
  */
 export async function mergeVuetifyModules (options: VuetifyModuleOptions, nuxt: Nuxt) {
@@ -65,25 +102,9 @@ export async function mergeVuetifyModules (options: VuetifyModuleOptions, nuxt: 
   //   for example, adding a layer with inlined vuetify options:
   //   nuxt will merge the conf for us (see issue #214 and #217)
   // - if the layer is configured using an external file, then we need to merge the configuration
-  if (moduleOptions.length > 1) {
-    const [app, ...rest] = moduleOptions
-    // we don't need to reverse (defu second arg are the defaults): fix #218
-    const configuration = <InlineModuleOptions>defu(app, ...rest)
-    // dedupe icons sets: fix #214 and #217
-    // we need to reverse the modules to override the icons from bottom to top layer
-    dedupeIcons(configuration, moduleOptions.toReversed())
-    return {
-      configuration,
-      vuetifyConfigurationFilesToWatch,
-    }
-  } else {
-    return {
-      configuration: {
-        moduleOptions: options.moduleOptions,
-        vuetifyOptions: resolvedOptions.config,
-      } satisfies InlineModuleOptions,
-      vuetifyConfigurationFilesToWatch,
-    }
+  return {
+    configuration: finalizeConfiguration(moduleOptions),
+    vuetifyConfigurationFilesToWatch,
   }
 }
 

--- a/packages/vuetify-nuxt-module/test/merge-modules.test.ts
+++ b/packages/vuetify-nuxt-module/test/merge-modules.test.ts
@@ -1,0 +1,61 @@
+import type { InlineModuleOptions } from '../src/types'
+import { describe, expect, it } from 'vitest'
+import { finalizeConfiguration, MODULE_DEFAULTS } from '../src/utils/layers'
+
+const app = (o: Partial<InlineModuleOptions>): InlineModuleOptions => ({ moduleOptions: {}, vuetifyOptions: {}, ...o })
+
+describe('finalizeConfiguration', () => {
+  it('applies module defaults when nothing overrides them', () => {
+    const c = finalizeConfiguration([app({})])
+    expect(c.moduleOptions!.styles).toBe(true)
+    expect(c.moduleOptions!.importComposables).toBe(true)
+    expect(c.vuetifyOptions!.directives).toBe(false)
+    expect(c.vuetifyOptions!.labComponents).toBe(false)
+  })
+
+  it('lets a hook/layer override a defaulted moduleOptions field (#290)', () => {
+    const c = finalizeConfiguration([
+      app({ moduleOptions: {} }),
+      { moduleOptions: { styles: 'none' }, vuetifyOptions: {} },
+    ])
+    expect(c.moduleOptions!.styles).toBe('none')
+  })
+
+  it('keeps the app explicit value above hooks/layers (#231)', () => {
+    const c = finalizeConfiguration([
+      app({ moduleOptions: { styles: false } }),
+      { moduleOptions: { styles: 'none' }, vuetifyOptions: {} },
+    ])
+    expect(c.moduleOptions!.styles).toBe(false)
+  })
+
+  it('orders hooks above layers (existing push order)', () => {
+    const c = finalizeConfiguration([
+      app({ moduleOptions: {} }),
+      { moduleOptions: { styles: 'none' }, vuetifyOptions: {} },
+      { moduleOptions: { styles: false }, vuetifyOptions: {} },
+    ])
+    expect(c.moduleOptions!.styles).toBe('none')
+  })
+
+  it('lets a hook override a defaulted vuetifyOptions field', () => {
+    const c = finalizeConfiguration([
+      app({ vuetifyOptions: {} }),
+      { moduleOptions: {}, vuetifyOptions: { directives: true } },
+    ])
+    expect(c.vuetifyOptions!.directives).toBe(true)
+  })
+
+  it('dedupes icons sets across entries (#214/#217)', () => {
+    const c = finalizeConfiguration([
+      app({ vuetifyOptions: { icons: { defaultSet: 'mdi', sets: [{ name: 'mdi' }] } } as any }),
+      { moduleOptions: {}, vuetifyOptions: { icons: { sets: [{ name: 'fa' }] } } as any },
+    ])
+    const names = (c.vuetifyOptions!.icons!.sets as Array<{ name: string }>).map(s => s.name).toSorted()
+    expect(names).toEqual(['fa', 'mdi'])
+  })
+
+  it('MODULE_DEFAULTS does not leak icons (dedupe only sees app+rest)', () => {
+    expect((MODULE_DEFAULTS.vuetifyOptions as any)?.icons).toBeUndefined()
+  })
+})

--- a/packages/vuetify-nuxt-module/test/merge-modules.test.ts
+++ b/packages/vuetify-nuxt-module/test/merge-modules.test.ts
@@ -58,4 +58,21 @@ describe('finalizeConfiguration', () => {
   it('MODULE_DEFAULTS does not leak icons (dedupe only sees app+rest)', () => {
     expect((MODULE_DEFAULTS.vuetifyOptions as any)?.icons).toBeUndefined()
   })
+
+  it('lets a layer (not just a hook) override a defaulted moduleOptions field (#290)', () => {
+    const c = finalizeConfiguration([
+      app({ moduleOptions: {} }), // app — no explicit styles
+      { moduleOptions: {}, vuetifyOptions: {} }, // hook — no styles
+      { moduleOptions: { styles: 'none' }, vuetifyOptions: {} }, // layer — overrides default
+    ])
+    expect(c.moduleOptions!.styles).toBe('none')
+  })
+
+  it('deep-merges rulesConfiguration: a hook provides configFile, default fills fromLabs (#290)', () => {
+    const c = finalizeConfiguration([
+      app({ moduleOptions: {} }),
+      { moduleOptions: { rulesConfiguration: { configFile: 'my-rules.ts' } }, vuetifyOptions: {} },
+    ])
+    expect(c.moduleOptions!.rulesConfiguration).toEqual({ configFile: 'my-rules.ts', fromLabs: true })
+  })
 })


### PR DESCRIPTION
## Summary

Closes #290. Module options registered via the `vuetify:registerModule` hook (and via layers) could not override module defaults such as `styles`.

## Root cause

Module defaults were declared in `defineNuxtModule.defaults()`, which Nuxt merges into `options` before `setup`. `mergeVuetifyModules` then unshifted the app config (now carrying those defaults) as the **base** of `defu(app, ...rest)`. Since `defu`'s earlier arguments win, any hook/layer `moduleOptions` in `...rest` could never override a defaulted field. (`vuetifyOptions` leaf overrides like theme colors worked only because the app config didn't set those leaves.)

## Fix

- Move defaults out of `defaults()` into a `MODULE_DEFAULTS` constant applied as the **last / lowest-priority** `defu` argument.
- Extract the merge into a pure, unit-tested `finalizeConfiguration()`.
- Resulting priority: **app (explicit) > hooks > layers > module defaults**.
- Preserves prior fixes: #218 (no reversal), #231 (app is base), #214/#217 (icons `sets` dedupe).
- Dropped a dead `disableVuetifyStyles` default (unused field, no consumers).

## Tests

`test/merge-modules.test.ts` (9 tests): defaults applied; hook overrides default; app beats hook; hook-over-layer ordering; layer overrides default; `vuetifyOptions` override; `rulesConfiguration` deep-merge; icons dedupe; defaults don't leak icons. Full suite: 50/50 passing.