### PR TITLE
docs(ssr): fix leading-slash configFile example

### DIFF
--- a/docs/guide/features/ssr.md
+++ b/docs/guide/features/ssr.md
@@ -29,7 +29,7 @@ export default defineNuxtConfig({
   vuetify: {
     moduleOptions: {
       /* other module options */
-      styles: { configFile: '/settings.scss' }
+      styles: { configFile: 'assets/settings.scss' }
     },
     vuetifyOptions: {
       /* vuetify options */


### PR DESCRIPTION
The SSR guide showed `styles: { configFile: '/settings.scss' }`. A leading-slash path is absolute (filesystem root) and won't resolve to the project — the module resolves a non-absolute `configFile` against each layer's `srcDir`. Aligned with the canonical srcDir-relative form used elsewhere in the docs (`guide/styling/common-setup.md`, `guide/styling/caching.md`). Spotted while triaging #338.