### PR TITLE
fix(deps): make vuetify a peerDependency (support Vuetify 3 & 4)

### DIFF
--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -40,7 +40,29 @@ You can also try it online on StackBlitz:
 
 ### Existing Project
 
-If you already have a Nuxt project, you can add the module using `nuxt`:
+If you already have a Nuxt project, first install `vuetify` — it is a peer dependency, so you choose the major version (Vuetify 3 or 4):
+
+::: code-group
+
+```bash [npm]
+npm install -D vuetify
+```
+
+```bash [yarn]
+yarn add -D vuetify
+```
+
+```bash [pnpm]
+pnpm add -D vuetify
+```
+
+```bash [bun]
+bun add -D vuetify
+```
+
+:::
+
+Then add the module using `nuxt`:
 
 ::: code-group
 

--- a/packages/vuetify-nuxt-module/README.md
+++ b/packages/vuetify-nuxt-module/README.md
@@ -51,7 +51,10 @@
 
 > Requires Vite, will not work with Webpack
 
+`vuetify` is a peer dependency (Vuetify 3 or 4) — install it alongside the module:
+
 ```bash
+npm install -D vuetify
 npx nuxt module add vuetify-nuxt-module
 ```
 

--- a/packages/vuetify-nuxt-module/package.json
+++ b/packages/vuetify-nuxt-module/package.json
@@ -86,8 +86,10 @@
     "perfect-debounce": "catalog:",
     "semver": "catalog:",
     "ufo": "catalog:",
-    "unconfig": "catalog:",
-    "vuetify": "catalog:"
+    "unconfig": "catalog:"
+  },
+  "peerDependencies": {
+    "vuetify": "^3.4.0 || ^4.0.0"
   },
   "devDependencies": {
     "@antfu/eslint-config": "catalog:",
@@ -119,7 +121,8 @@
     "typescript": "catalog:",
     "vite": "catalog:",
     "vitest": "catalog:",
-    "vue-tsc": "catalog:"
+    "vue-tsc": "catalog:",
+    "vuetify": "catalog:"
   },
   "build": {
     "externals": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -479,9 +479,6 @@ importers:
       unconfig:
         specifier: 'catalog:'
         version: 7.5.0
-      vuetify:
-        specifier: 'catalog:'
-        version: 4.0.1(typescript@5.9.3)(vite-plugin-vuetify@2.1.3)(vue@3.5.29(typescript@5.9.3))
     devDependencies:
       '@antfu/eslint-config':
         specifier: 'catalog:'
@@ -573,6 +570,9 @@ importers:
       vue-tsc:
         specifier: 'catalog:'
         version: 3.2.5(typescript@5.9.3)
+      vuetify:
+        specifier: 'catalog:'
+        version: 4.0.1(typescript@5.9.3)(vite-plugin-vuetify@2.1.3)(vue@3.5.29(typescript@5.9.3))
 
 packages:
 


### PR DESCRIPTION
## Problem

`vuetify` was a hard **`dependency`** of the module, pinned via the workspace catalog to **`^4.0.1`**. But the module supports **both Vuetify 3 and 4** (`vuetifyGte('3.4.0' / '3.5.0' / '3.8.0' / '3.10.0')` branches, a `vuetify/labs/date` fallback for <3.4, a `basic-vuetify3` test fixture on `vuetify@^3.7.0`, v3 notes in the docs).

Shipping a hard `vuetify@^4` dependency means a consumer who wants Vuetify 3 still gets v4 pulled in transitively → duplicate/conflicting versions and ambiguous resolution. It also takes version control away from the consumer for the UI library they actually use.

## Fix

Move `vuetify` to **`peerDependencies`** with a range covering both majors, and keep it as a `devDependency` for the module's own build/tests:

```jsonc
"peerDependencies": { "vuetify": "^3.4.0 || ^4.0.0" },
"devDependencies":  { "vuetify": "catalog:" }   // module dev/build/tests
// removed from "dependencies"
```

The module already resolves `vuetify` from the consumer's project and throws a clear *"add it as a dependency"* error when missing — i.e. it already assumes the peer-dependency contract. `vite-plugin-vuetify` / `@vuetify/unplugin-styles` remain dependencies (build tooling the module owns).

## Docs

Updated the install instructions (README + `docs/guide/index.md` "Existing Project") to add an explicit `vuetify` install step, since it is now a peer dependency. Closes #330.

## Verification
- Full test suite: 53/53 passing (incl. the real-build fixtures `basic`, `sass`, `layers`, **`basic-vuetify3`**).
- `prepack` build succeeds (vuetify is externalized; types resolve via the devDependency).
- Lint clean (no new issues).

## Note
Consumers should now install `vuetify` explicitly (pnpm's `auto-install-peers` handles it automatically).