### PR TITLE
refactor(deps): drop vite-plugin-vuetify in favor of @vuetify/loader-shared

### DIFF
--- a/apps/playground/nuxt.config.ts
+++ b/apps/playground/nuxt.config.ts
@@ -1,7 +1,5 @@
 import { availableLocales, langDir } from './config/i18n'
 
-// import { transformAssetUrls } from "vite-plugin-vuetify";
-
 export default defineNuxtConfig({
   compatibilityDate: '2024-08-15',
   // ssr: false,

--- a/packages/vuetify-nuxt-module/package.json
+++ b/packages/vuetify-nuxt-module/package.json
@@ -77,6 +77,7 @@
   },
   "dependencies": {
     "@nuxt/kit": "catalog:",
+    "@vuetify/loader-shared": "catalog:",
     "@vuetify/unplugin-styles": "catalog:",
     "defu": "catalog:",
     "destr": "catalog:",
@@ -86,7 +87,6 @@
     "semver": "catalog:",
     "ufo": "catalog:",
     "unconfig": "catalog:",
-    "vite-plugin-vuetify": "catalog:",
     "vuetify": "catalog:"
   },
   "devDependencies": {
@@ -139,7 +139,6 @@
       "ufo",
       "unconfig",
       "vite",
-      "vite-plugin-vuetify",
       "vuetify"
     ]
   },

--- a/packages/vuetify-nuxt-module/src/utils/index.ts
+++ b/packages/vuetify-nuxt-module/src/utils/index.ts
@@ -2,7 +2,7 @@ import type { ViteConfig } from '@nuxt/schema'
 import type { AssetURLOptions, AssetURLTagConfig } from '@vue/compiler-sfc'
 import type { VuetifyNuxtContext } from './config'
 import defu from 'defu'
-import { transformAssetUrls as vuetifyTransformAssetUrls } from 'vite-plugin-vuetify'
+import { transformAssetUrls as vuetifyTransformAssetUrls } from '@vuetify/loader-shared'
 
 /**
  * Convert string to kebap-case

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -108,6 +108,9 @@ catalogs:
     '@vite-pwa/vitepress':
       specifier: ^1.1.0
       version: 1.1.0
+    '@vuetify/loader-shared':
+      specifier: ^2.1.2
+      version: 2.1.2
     '@vuetify/unplugin-styles':
       specifier: ^1.0.0-beta.11
       version: 1.0.0-beta.11
@@ -201,9 +204,6 @@ catalogs:
     vite-plugin-pwa:
       specifier: ^1.2.0
       version: 1.2.0
-    vite-plugin-vuetify:
-      specifier: ^2.1.3
-      version: 2.1.3
     vitepress-plugin-llms:
       specifier: ^1.11.0
       version: 1.11.0
@@ -449,6 +449,9 @@ importers:
       '@nuxt/kit':
         specifier: 'catalog:'
         version: 4.4.2(magicast@0.5.2)
+      '@vuetify/loader-shared':
+        specifier: 'catalog:'
+        version: 2.1.2(vue@3.5.29(typescript@5.9.3))(vuetify@4.0.1)
       '@vuetify/unplugin-styles':
         specifier: 'catalog:'
         version: 1.0.0-beta.11(@nuxt/kit@4.4.2(magicast@0.5.2))(@nuxt/schema@4.3.1)(sass-embedded@1.97.3)(sass@1.97.3)(vite@7.3.1(@types/node@25.3.3)(jiti@2.6.1)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.88.2(esbuild@0.27.3))
@@ -476,9 +479,6 @@ importers:
       unconfig:
         specifier: 'catalog:'
         version: 7.5.0
-      vite-plugin-vuetify:
-        specifier: 'catalog:'
-        version: 2.1.3(vite@7.3.1(@types/node@25.3.3)(jiti@2.6.1)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(vue@3.5.29(typescript@5.9.3))(vuetify@4.0.1)
       vuetify:
         specifier: 'catalog:'
         version: 4.0.1(typescript@5.9.3)(vite-plugin-vuetify@2.1.3)(vue@3.5.29(typescript@5.9.3))
@@ -16796,6 +16796,7 @@ snapshots:
       vuetify: 4.0.1(typescript@5.9.3)(vite-plugin-vuetify@2.1.3)(vue@3.5.29(typescript@5.9.3))
     transitivePeerDependencies:
       - supports-color
+    optional: true
 
   vite@7.3.1(@types/node@25.3.3)(jiti@2.6.1)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2):
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -38,6 +38,7 @@ catalog:
   '@unocss/nuxt': ^66.6.5
   '@vite-pwa/assets-generator': ^1.0.2
   '@vite-pwa/vitepress': ^1.1.0
+  '@vuetify/loader-shared': ^2.1.2
   '@vuetify/unplugin-styles': ^1.0.0-beta.11
   bumpp: ^10.4.1
   conventional-github-releaser: ^3.1.5
@@ -70,7 +71,6 @@ catalog:
   unocss: ^66.6.5
   vite: 7.3.1
   vite-plugin-pwa: ^1.2.0
-  vite-plugin-vuetify: ^2.1.3
   vitepress: 2.0.0-alpha.16
   vitepress-plugin-llms: ^1.11.0
   vitest: ^4.0.18


### PR DESCRIPTION
`vite-plugin-vuetify` only re-exported `transformAssetUrls` from `@vuetify/loader-shared`, which this module already depends on directly (used in `configure-vite.ts` and `vuetify-import-plugin.ts`).

## Changes
- Import `transformAssetUrls` from `@vuetify/loader-shared` instead of `vite-plugin-vuetify` in `src/utils/index.ts`.
- Declare `@vuetify/loader-shared` as a direct dependency (it was previously a phantom dep — used in source but undeclared).
- Drop the `vite-plugin-vuetify` dependency, build external, and catalog entry.
- Remove a leftover commented-out import in the playground config.

The remaining `vite-plugin-vuetify` mentions in source are intentional user-facing error messages (instructing users to remove the plugin from their own Nuxt config).

## Verification
- Module builds clean; no real `vite-plugin-vuetify` imports remain in dist.
- `publint`: all good.
- Full test suite: 53/53 passing.